### PR TITLE
Update safe area styling for status bar

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,30 +87,32 @@ function ScheduleApp() {
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
-      <StatusBar barStyle="dark-content" />
+    <SafeAreaView style={{ backgroundColor: '#000' }} edges={['top', 'left', 'right']}>
+      <StatusBar barStyle="light-content" backgroundColor="#000" />
 
-      <View style={[styles.content, dynamicStyles.content]}>
-        <Text style={styles.heading}>Daily Routine</Text>
-        <Text style={[styles.description, dynamicStyles.description]}>
-          {activeTab === 'today'
-            ? 'Review what you planned for today, check off completed habits, and add new tasks as needed.'
-            : 'Open the calendar to plan ahead, review upcoming routines, and adjust your schedule.'}
-        </Text>
-      </View>
-
-      <View style={[styles.bottomBarContainer, dynamicStyles.bottomBarContainer]}>
-        <View style={[styles.bottomBar, dynamicStyles.bottomBar]}>
-          {TABS.map(renderTabButton)}
+      <View style={styles.container}>
+        <View style={[styles.content, dynamicStyles.content]}>
+          <Text style={styles.heading}>Daily Routine</Text>
+          <Text style={[styles.description, dynamicStyles.description]}>
+            {activeTab === 'today'
+              ? 'Review what you planned for today, check off completed habits, and add new tasks as needed.'
+              : 'Open the calendar to plan ahead, review upcoming routines, and adjust your schedule.'}
+          </Text>
         </View>
 
-        <TouchableOpacity
-          style={[styles.addButton, dynamicStyles.addButton]}
-          accessibilityRole="button"
-          accessibilityLabel="Add new routine"
-        >
-          <Ionicons name="add" size={32} color="#fff" />
-        </TouchableOpacity>
+        <View style={[styles.bottomBarContainer, dynamicStyles.bottomBarContainer]}>
+          <View style={[styles.bottomBar, dynamicStyles.bottomBar]}>
+            {TABS.map(renderTabButton)}
+          </View>
+
+          <TouchableOpacity
+            style={[styles.addButton, dynamicStyles.addButton]}
+            accessibilityRole="button"
+            accessibilityLabel="Add new routine"
+          >
+            <Ionicons name="add" size={32} color="#fff" />
+          </TouchableOpacity>
+        </View>
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- set the top safe area background to black to blend with the status bar
- wrap the schedule content in the existing light container to preserve the original layout
- switch the status bar to light-content with a black background for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc10e10978832680c6b1eb5676f826