### PR TITLE
Revert FAB card scaling and enlarge icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ function ScheduleApp() {
   const bottomBarPadding = useMemo(() => Math.max(20, horizontalPadding), [horizontalPadding]);
   const iconSize = isCompact ? 22 : 24;
   const cardSize = isCompact ? 136 : 152;
-  const cardIconSize = isCompact ? 52 : 60;
+  const cardIconSize = isCompact ? 68 : 80;
   const cardSpacing = isCompact ? 16 : 24;
   const cardBorderRadius = isCompact ? 30 : 34;
   const cardVerticalOffset = isCompact ? 116 : 132;


### PR DESCRIPTION
## Summary
- revert the previous floating action card dimension tweaks so the layout matches its earlier proportions
- enlarge only the FAB action illustrations by increasing the shared card icon size constant for compact and regular layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fce15f28348326b1d5b6a00efadf60