### PR TITLE
Enable custom tags and interactive subtasks

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -110,7 +110,7 @@ const REMINDER_OPTIONS = [
   { key: '1h', label: '1 hour early', offsetMinutes: -60 },
 ];
 
-const TAG_OPTIONS = [
+const DEFAULT_TAG_OPTIONS = [
   { key: 'none', label: 'No tag' },
   { key: 'clean_room', label: 'Clean Room' },
   { key: 'healthy_lifestyle', label: 'Healthy Lifestyle' },
@@ -119,6 +119,23 @@ const TAG_OPTIONS = [
   { key: 'sleep_better', label: 'Sleep Better' },
   { key: 'workout', label: 'Workout' },
 ];
+
+const createTagKey = (label, existingKeys) => {
+  const sanitized = label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 40);
+  const base = sanitized || 'tag';
+  let candidate = base;
+  let suffix = 1;
+  while (existingKeys.has(candidate)) {
+    candidate = `${base}_${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+};
 
 const HOUR_VALUES = Array.from({ length: 12 }, (_, i) => i + 1);
 const MINUTE_VALUES = Array.from({ length: 60 }, (_, i) => i);
@@ -291,12 +308,35 @@ function minutesToTime(totalMinutes) {
   return { hour: hour12, minute, meridiem };
 }
 
-function ensureValidPeriod(period) {
-  const startMinutes = timeToMinutes(period.start);
-  let endMinutes = timeToMinutes(period.end);
-  if (endMinutes <= startMinutes) {
-    endMinutes = startMinutes + 30;
+function normalizeTimeValue(time) {
+  if (!time) {
+    return time;
   }
+  return minutesToTime(timeToMinutes(time));
+}
+
+function ensureValidPeriod(period, { allowFlipEndMeridiem = false } = {}) {
+  const normalizedStart = normalizeTimeValue(period.start);
+  let normalizedEnd = normalizeTimeValue(period.end);
+
+  const startMinutes = timeToMinutes(normalizedStart);
+  let endMinutes = timeToMinutes(normalizedEnd);
+
+  if (allowFlipEndMeridiem && endMinutes < startMinutes) {
+    const flippedMeridiem = normalizedEnd.meridiem === 'AM' ? 'PM' : 'AM';
+    const flippedEnd = { ...normalizedEnd, meridiem: flippedMeridiem };
+    const flippedMinutes = timeToMinutes(flippedEnd);
+    if (flippedMinutes >= startMinutes) {
+      normalizedEnd = flippedEnd;
+      endMinutes = flippedMinutes;
+    }
+  }
+
+  if (endMinutes < startMinutes) {
+    normalizedEnd = { ...normalizedStart };
+    endMinutes = startMinutes;
+  }
+
   return {
     start: minutesToTime(startMinutes),
     end: minutesToTime(endMinutes),
@@ -319,12 +359,12 @@ function getReminderHint(option, hasSpecifiedTime, timeMode, pointTime, periodTi
   }
   const reference = getReminderReferenceTime(hasSpecifiedTime, timeMode, pointTime, periodTime);
   if (!reference || typeof option.offsetMinutes !== 'number') {
-    return '(No time set)';
+    return 'No time set';
   }
   const baseMinutes = timeToMinutes(reference);
   const reminderMinutes = baseMinutes + option.offsetMinutes;
   const reminderTime = minutesToTime(reminderMinutes);
-  return `(${formatTime(reminderTime)})`;
+  return formatTime(reminderTime);
 }
 
 export default function AddHabitSheet({ visible, onClose, onCreate }) {
@@ -351,7 +391,9 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
     end: { hour: 10, minute: 0, meridiem: 'AM' },
   });
   const [reminderOption, setReminderOption] = useState('none');
+  const [tagOptions, setTagOptions] = useState(() => [...DEFAULT_TAG_OPTIONS]);
   const [selectedTag, setSelectedTag] = useState('none');
+  const [subtasks, setSubtasks] = useState([]);
 
   const [calendarMonth, setCalendarMonth] = useState(() => new Date(startDate.getFullYear(), startDate.getMonth(), 1));
   const [pendingDate, setPendingDate] = useState(startDate);
@@ -363,11 +405,39 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
   const [pendingPeriodTime, setPendingPeriodTime] = useState(periodTime);
   const [pendingReminder, setPendingReminder] = useState(reminderOption);
   const [pendingTag, setPendingTag] = useState(selectedTag);
+  const [pendingSubtasks, setPendingSubtasks] = useState([]);
   const titleInputRef = useRef(null);
   const translateY = useRef(new Animated.Value(sheetHeight || height)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const isClosingRef = useRef(false);
   const sheetBackgroundColor = useMemo(() => lightenColor(selectedColor, 0.75), [selectedColor]);
+
+  const handlePendingPointTimeChange = useCallback((next) => {
+    setPendingPointTime((prev) => {
+      const resolved = typeof next === 'function' ? next(prev) : next;
+      return normalizeTimeValue(resolved);
+    });
+  }, []);
+
+  const handlePendingPeriodTimeChange = useCallback((updater) => {
+    setPendingPeriodTime((prev) => {
+      const resolved = typeof updater === 'function' ? updater(prev) : updater;
+      const hasStartUpdate = resolved?.start != null;
+      const hasEndUpdate = resolved?.end != null;
+      const nextStart = hasStartUpdate ? normalizeTimeValue(resolved.start) : prev.start;
+      const nextEnd = hasEndUpdate ? normalizeTimeValue(resolved.end) : prev.end;
+
+      return ensureValidPeriod(
+        {
+          start: nextStart,
+          end: nextEnd,
+        },
+        {
+          allowFlipEndMeridiem: hasEndUpdate && !hasStartUpdate,
+        }
+      );
+    });
+  }, []);
 
   const handleClose = useCallback(() => {
     if (!visible) {
@@ -398,8 +468,8 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
       } else if (panel === 'time') {
         setPendingHasSpecifiedTime(hasSpecifiedTime);
         setPendingTimeMode(timeMode);
-        setPendingPointTime({ ...pointTime });
-        setPendingPeriodTime({
+        handlePendingPointTimeChange({ ...pointTime });
+        handlePendingPeriodTimeChange({
           start: { ...periodTime.start },
           end: { ...periodTime.end },
         });
@@ -407,10 +477,15 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
         setPendingReminder(reminderOption);
       } else if (panel === 'tag') {
         setPendingTag(selectedTag);
+      } else if (panel === 'subtasks') {
+        setPendingSubtasks(subtasks);
       }
     },
     [
+      handlePendingPeriodTimeChange,
+      handlePendingPointTimeChange,
       hasSpecifiedTime,
+      subtasks,
       periodTime,
       pointTime,
       reminderOption,
@@ -459,8 +534,12 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
   const handleApplyTime = useCallback(() => {
     setHasSpecifiedTime(pendingHasSpecifiedTime);
     setTimeMode(pendingTimeMode);
-    setPointTime(pendingPointTime);
-    setPeriodTime(ensureValidPeriod(pendingPeriodTime));
+    const normalizedPoint = normalizeTimeValue(pendingPointTime);
+    const normalizedPeriod = ensureValidPeriod(pendingPeriodTime, { allowFlipEndMeridiem: true });
+    setPointTime(normalizedPoint);
+    setPeriodTime(normalizedPeriod);
+    setPendingPointTime(normalizedPoint);
+    setPendingPeriodTime(normalizedPeriod);
     closePanel();
   }, [
     closePanel,
@@ -479,6 +558,42 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
     setSelectedTag(pendingTag);
     closePanel();
   }, [closePanel, pendingTag]);
+
+  const handleApplySubtasks = useCallback(() => {
+    const sanitized = pendingSubtasks
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+    setSubtasks(sanitized);
+    setPendingSubtasks(sanitized);
+    closePanel();
+  }, [closePanel, pendingSubtasks, setPendingSubtasks, setSubtasks]);
+
+  const handleCreateCustomTag = useCallback(
+    (label) => {
+      const trimmed = label.trim();
+      if (!trimmed) {
+        return { key: null, created: false };
+      }
+      let outcome = { key: null, created: false };
+      setTagOptions((prev) => {
+        const normalized = trimmed.toLowerCase();
+        const existing = prev.find((option) => option.label.toLowerCase() === normalized);
+        if (existing) {
+          setPendingTag(existing.key);
+          outcome = { key: existing.key, created: false };
+          return prev;
+        }
+        const existingKeys = new Set(prev.map((option) => option.key));
+        const key = createTagKey(trimmed, existingKeys);
+        const nextOption = [...prev, { key, label: trimmed }];
+        setPendingTag(key);
+        outcome = { key, created: true };
+        return nextOption;
+      });
+      return outcome;
+    },
+    [setPendingTag, setTagOptions]
+  );
 
   useEffect(() => {
     if (visible) {
@@ -535,6 +650,9 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
           });
           setReminderOption('none');
           setSelectedTag('none');
+          setPendingTag('none');
+          setSubtasks([]);
+          setPendingSubtasks([]);
         }
       });
     }
@@ -571,6 +689,8 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
     if (!title.trim()) {
       return;
     }
+    const selectedTagOption =
+      tagOptions.find((option) => option.key === selectedTag) ?? tagOptions[0];
     onCreate?.({
       title: title.trim(),
       color: selectedColor,
@@ -584,7 +704,9 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
         period: periodTime,
       },
       reminder: reminderOption,
-      tag: selectedTag,
+      tag: selectedTagOption.key,
+      tagLabel: selectedTagOption.label,
+      subtasks,
     });
     handleClose();
   }, [
@@ -597,11 +719,13 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
     selectedColor,
     selectedEmoji,
     selectedTag,
+    tagOptions,
     selectedWeekdays,
     startDate,
     timeMode,
     title,
     reminderOption,
+    subtasks,
   ]);
 
   const panResponder = useMemo(
@@ -664,15 +788,29 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
     () => getRepeatLabel(repeatOption, selectedWeekdays, startDate),
     [repeatOption, selectedWeekdays, startDate]
   );
+  const normalizedPointTime = useMemo(() => normalizeTimeValue(pointTime), [pointTime]);
+  const normalizedPeriodTime = useMemo(
+    () => ensureValidPeriod(periodTime, { allowFlipEndMeridiem: true }),
+    [periodTime]
+  );
+  const normalizedPendingPointTime = useMemo(
+    () => normalizeTimeValue(pendingPointTime),
+    [pendingPointTime]
+  );
+  const normalizedPendingPeriodTime = useMemo(
+    () => ensureValidPeriod(pendingPeriodTime, { allowFlipEndMeridiem: true }),
+    [pendingPeriodTime]
+  );
+
   const timeValue = useMemo(() => {
     if (!hasSpecifiedTime) {
       return 'Anytime';
     }
     if (timeMode === 'point') {
-      return formatTime(pointTime);
+      return formatTime(normalizedPointTime);
     }
-    return formatPeriod(periodTime);
-  }, [hasSpecifiedTime, periodTime, pointTime, timeMode]);
+    return formatPeriod(normalizedPeriodTime);
+  }, [hasSpecifiedTime, normalizedPeriodTime, normalizedPointTime, timeMode]);
   const reminderOptions = useMemo(
     () =>
       REMINDER_OPTIONS.map((option) => ({
@@ -683,29 +821,39 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
   );
   const reminderLabel = useMemo(() => {
     const match = reminderOptions.find((option) => option.key === reminderOption);
-    if (!match) {
+    if (!match || match.key === 'none') {
       return 'No reminder';
     }
-    if (match.hint) {
-      return `${match.label} ${match.hint}`;
-    }
-    return match.label;
+    return match.hint ?? 'No time set';
   }, [reminderOption, reminderOptions]);
   const tagLabel = useMemo(() => {
-    const match = TAG_OPTIONS.find((option) => option.key === selectedTag);
+    const match = tagOptions.find((option) => option.key === selectedTag);
     return match?.label ?? 'No tag';
-  }, [selectedTag]);
+  }, [selectedTag, tagOptions]);
+
+  const subtaskLabel = useMemo(() => {
+    if (subtasks.length === 0) {
+      return 'Add';
+    }
+    return `${subtasks.length} added`;
+  }, [subtasks]);
 
   const pendingTimeTitle = useMemo(() => {
     if (!pendingHasSpecifiedTime) {
       return 'Do it any time of the day';
     }
     if (pendingTimeMode === 'period') {
-      const normalized = ensureValidPeriod(pendingPeriodTime);
-      return `Do it from ${formatTime(normalized.start)} to ${formatTime(normalized.end)} of the day`;
+      const startLabel = formatTime(normalizedPendingPeriodTime.start);
+      const endLabel = formatTime(normalizedPendingPeriodTime.end);
+      return `Do it from ${startLabel} to ${endLabel} of the day`;
     }
-    return `Do it at ${formatTime(pendingPointTime)} of the day`;
-  }, [pendingHasSpecifiedTime, pendingPeriodTime, pendingPointTime, pendingTimeMode]);
+    return `Do it at ${formatTime(normalizedPendingPointTime)} of the day`;
+  }, [
+    normalizedPendingPeriodTime,
+    normalizedPendingPointTime,
+    pendingHasSpecifiedTime,
+    pendingTimeMode,
+  ]);
 
   if (!isMounted) {
     return null;
@@ -893,10 +1041,23 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
                     </View>
                   )}
                   label="Subtasks"
-                  value="Add"
+                  value={subtaskLabel}
                   showChevron
+                  onPress={() => handleOpenPanel('subtasks')}
                   isLast
                 />
+                {subtasks.length > 0 ? (
+                  <View style={styles.subtasksPreviewList}>
+                    {subtasks.map((item, index) => (
+                      <View key={`${item}-${index}`} style={styles.subtasksPreviewItem}>
+                        <View style={styles.subtasksPreviewBullet} />
+                        <Text style={styles.subtasksPreviewText} numberOfLines={1}>
+                          {item}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                ) : null}
                 <Text style={styles.subtasksHint}>
                   Subtasks can be set as your daily routine or checklist
                 </Text>
@@ -956,13 +1117,9 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
                   mode={pendingTimeMode}
                   onModeChange={setPendingTimeMode}
                   pointTime={pendingPointTime}
-                  onPointTimeChange={setPendingPointTime}
+                  onPointTimeChange={handlePendingPointTimeChange}
                   periodTime={pendingPeriodTime}
-                  onPeriodTimeChange={(updater) => {
-                    setPendingPeriodTime((prev) =>
-                      typeof updater === 'function' ? updater(prev) : updater
-                    );
-                  }}
+                  onPeriodTimeChange={handlePendingPeriodTimeChange}
                 />
               </OptionOverlay>
             )}
@@ -985,7 +1142,22 @@ export default function AddHabitSheet({ visible, onClose, onCreate }) {
                 onClose={closePanel}
                 onApply={handleApplyTag}
               >
-                <OptionList options={TAG_OPTIONS} selectedKey={pendingTag} onSelect={setPendingTag} />
+                <TagPanel
+                  options={tagOptions}
+                  selectedKey={pendingTag}
+                  onSelect={setPendingTag}
+                  onCreateTag={handleCreateCustomTag}
+                />
+              </OptionOverlay>
+            )}
+            {activePanel === 'subtasks' && (
+              <OptionOverlay
+                title="Subtasks"
+                onClose={closePanel}
+                onApply={handleApplySubtasks}
+                applyLabel="Done"
+              >
+                <SubtasksPanel value={pendingSubtasks} onChange={setPendingSubtasks} />
               </OptionOverlay>
             )}
           </SafeAreaView>
@@ -1115,6 +1287,135 @@ function OptionList({ options, selectedKey, onSelect }) {
           </Pressable>
         );
       })}
+    </View>
+  );
+}
+
+function TagPanel({ options, selectedKey, onSelect, onCreateTag }) {
+  const [newTagName, setNewTagName] = useState('');
+  const trimmed = newTagName.trim();
+  const isDisabled = trimmed.length === 0;
+
+  const handleAddTag = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+    const result = onCreateTag(trimmed);
+    if (result?.key) {
+      setNewTagName('');
+    }
+  }, [isDisabled, onCreateTag, trimmed]);
+
+  return (
+    <View style={styles.tagPanel}>
+      <OptionList options={options} selectedKey={selectedKey} onSelect={onSelect} />
+      <View style={styles.tagCreator}>
+        <TextInput
+          style={styles.tagInput}
+          placeholder="Create new tag"
+          placeholderTextColor="#7F8A9A"
+          value={newTagName}
+          onChangeText={setNewTagName}
+          onSubmitEditing={handleAddTag}
+          returnKeyType="done"
+          maxLength={30}
+          accessibilityLabel="Create new tag"
+        />
+        <Pressable
+          style={[styles.tagAddButton, isDisabled && styles.tagAddButtonDisabled]}
+          onPress={handleAddTag}
+          disabled={isDisabled}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: isDisabled }}
+        >
+          <Text style={[styles.tagAddButtonText, isDisabled && styles.tagAddButtonTextDisabled]}>
+            Add
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function SubtasksPanel({ value, onChange }) {
+  const [draft, setDraft] = useState('');
+  const trimmedDraft = draft.trim();
+  const isDisabled = trimmedDraft.length === 0;
+  const list = Array.isArray(value) ? value : [];
+
+  const handleAdd = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+    onChange((prev) => {
+      const next = Array.isArray(prev) ? [...prev] : [];
+      next.push(trimmedDraft);
+      return next;
+    });
+    setDraft('');
+  }, [isDisabled, onChange, trimmedDraft]);
+
+  const handleRemove = useCallback(
+    (index) => {
+      onChange((prev) => prev.filter((_, itemIndex) => itemIndex !== index));
+    },
+    [onChange]
+  );
+
+  return (
+    <View style={styles.subtasksPanel}>
+      <View style={styles.subtasksList}>
+        {list.length === 0 ? (
+          <Text style={styles.subtasksEmpty}>No subtasks yet</Text>
+        ) : (
+          list.map((item, index) => {
+            const isLast = index === list.length - 1;
+            return (
+              <View key={`${item}-${index}`} style={[styles.subtaskRow, isLast && styles.subtaskRowLast]}>
+                <View style={styles.subtaskRowLeft}>
+                  <Ionicons name="ellipse-outline" size={18} color="#9aa0af" />
+                  <Text style={styles.subtaskName}>{item}</Text>
+                </View>
+                <Pressable
+                  onPress={() => handleRemove(index)}
+                  accessibilityLabel={`Remove subtask ${item}`}
+                  accessibilityRole="button"
+                  hitSlop={8}
+                >
+                  <Ionicons name="close-circle" size={20} color="#9aa0af" />
+                </Pressable>
+              </View>
+            );
+          })
+        )}
+      </View>
+      <View style={styles.subtaskInputRow}>
+        <Ionicons name="add-circle-outline" size={22} color="#61708A" />
+        <TextInput
+          style={styles.subtaskInput}
+          placeholder="New subtask"
+          placeholderTextColor="#7F8A9A"
+          value={draft}
+          onChangeText={setDraft}
+          onSubmitEditing={handleAdd}
+          returnKeyType="done"
+          accessibilityLabel="New subtask"
+        />
+        <Pressable
+          style={[styles.subtaskAddButton, isDisabled && styles.subtaskAddButtonDisabled]}
+          onPress={handleAdd}
+          disabled={isDisabled}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: isDisabled }}
+        >
+          <Text
+            style={[styles.subtaskAddButtonText, isDisabled && styles.subtaskAddButtonTextDisabled]}
+          >
+            Add
+          </Text>
+        </Pressable>
+      </View>
+      <Text style={styles.subtasksPanelHint}>Subtasks can be set as your daily routine or checklist</Text>
     </View>
   );
 }
@@ -1464,10 +1765,9 @@ function TimePanel({
                       values={HOUR_VALUES}
                       selectedIndex={startHourIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: { ...periodTime.start, hour: value },
-                          end: periodTime.end,
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          start: { ...prev.start, hour: value },
+                        }))
                       }
                       formatter={(value) => formatNumber(value)}
                     />
@@ -1478,10 +1778,9 @@ function TimePanel({
                       values={MINUTE_VALUES}
                       selectedIndex={startMinuteIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: { ...periodTime.start, minute: value },
-                          end: periodTime.end,
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          start: { ...prev.start, minute: value },
+                        }))
                       }
                       formatter={(value) => formatNumber(value)}
                     />
@@ -1489,10 +1788,9 @@ function TimePanel({
                       values={MERIDIEM_VALUES}
                       selectedIndex={startMeridiemIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: { ...periodTime.start, meridiem: value },
-                          end: periodTime.end,
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          start: { ...prev.start, meridiem: value },
+                        }))
                       }
                     />
                   </View>
@@ -1512,10 +1810,9 @@ function TimePanel({
                       values={HOUR_VALUES}
                       selectedIndex={endHourIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: periodTime.start,
-                          end: { ...periodTime.end, hour: value },
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          end: { ...prev.end, hour: value },
+                        }))
                       }
                       formatter={(value) => formatNumber(value)}
                     />
@@ -1526,10 +1823,9 @@ function TimePanel({
                       values={MINUTE_VALUES}
                       selectedIndex={endMinuteIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: periodTime.start,
-                          end: { ...periodTime.end, minute: value },
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          end: { ...prev.end, minute: value },
+                        }))
                       }
                       formatter={(value) => formatNumber(value)}
                     />
@@ -1537,10 +1833,9 @@ function TimePanel({
                       values={MERIDIEM_VALUES}
                       selectedIndex={endMeridiemIndex}
                       onSelect={(value) =>
-                        onPeriodTimeChange({
-                          start: periodTime.start,
-                          end: { ...periodTime.end, meridiem: value },
-                        })
+                        onPeriodTimeChange((prev) => ({
+                          end: { ...prev.end, meridiem: value },
+                        }))
                       }
                     />
                   </View>
@@ -1603,13 +1898,21 @@ function WheelColumn({
       const index = Math.round(clampedOffset / itemHeight);
       const clampedIndex = Math.min(Math.max(index, 0), values.length - 1);
       const targetOffset = offsets[clampedIndex] ?? clampedIndex * itemHeight;
-      scrollRef.current?.scrollTo({ y: targetOffset, animated: true });
-      onSelect(values[clampedIndex]);
-      if (typeof Haptics.selectionAsync === 'function') {
-        Haptics.selectionAsync();
+
+      const distanceToTarget = Math.abs(targetOffset - clampedOffset);
+      const shouldAnimate = distanceToTarget > 0.5;
+      if (distanceToTarget > 0) {
+        scrollRef.current?.scrollTo({ y: targetOffset, animated: shouldAnimate });
+      }
+
+      if (clampedIndex !== selectedIndex) {
+        onSelect(values[clampedIndex]);
+        if (typeof Haptics.selectionAsync === 'function') {
+          Haptics.selectionAsync();
+        }
       }
     },
-    [itemHeight, offsets, onSelect, values]
+    [itemHeight, offsets, onSelect, selectedIndex, values]
   );
 
   const handleMomentumBegin = useCallback(() => {
@@ -1837,6 +2140,26 @@ const styles = StyleSheet.create({
     shadowRadius: 12,
     elevation: 6,
   },
+  subtasksPreviewList: {
+    marginTop: 12,
+    gap: 8,
+  },
+  subtasksPreviewItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  subtasksPreviewBullet: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: '#B8C4D6',
+  },
+  subtasksPreviewText: {
+    flex: 1,
+    color: '#1F2742',
+    fontSize: 15,
+  },
   subtasksHint: {
     color: '#7F8A9A',
     fontSize: 13,
@@ -1947,6 +2270,47 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     overflow: 'hidden',
   },
+  tagPanel: {
+    gap: 18,
+  },
+  tagCreator: {
+    marginTop: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: '#EEF3FF',
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  tagInput: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 15,
+    color: '#1F2742',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(109, 125, 150, 0.16)',
+  },
+  tagAddButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: '#1F2742',
+  },
+  tagAddButtonDisabled: {
+    backgroundColor: '#B8C4D6',
+  },
+  tagAddButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  tagAddButtonTextDisabled: {
+    opacity: 0.6,
+  },
   optionItem: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1995,6 +2359,80 @@ const styles = StyleSheet.create({
     height: 10,
     borderRadius: 5,
     backgroundColor: '#1F2742',
+  },
+  subtasksPanel: {
+    gap: 20,
+  },
+  subtasksList: {
+    backgroundColor: '#F5F7FF',
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  subtasksEmpty: {
+    textAlign: 'center',
+    color: '#7F8A9A',
+    paddingVertical: 20,
+    fontSize: 15,
+  },
+  subtaskRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(109, 125, 150, 0.12)',
+  },
+  subtaskRowLast: {
+    borderBottomWidth: 0,
+  },
+  subtaskRowLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    flex: 1,
+  },
+  subtaskName: {
+    flex: 1,
+    color: '#1F2742',
+    fontSize: 15,
+  },
+  subtaskInputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: '#EEF3FF',
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  subtaskInput: {
+    flex: 1,
+    fontSize: 15,
+    color: '#1F2742',
+  },
+  subtaskAddButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 14,
+    backgroundColor: '#1F2742',
+  },
+  subtaskAddButtonDisabled: {
+    backgroundColor: '#B8C4D6',
+  },
+  subtaskAddButtonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 15,
+  },
+  subtaskAddButtonTextDisabled: {
+    opacity: 0.6,
+  },
+  subtasksPanelHint: {
+    color: '#7F8A9A',
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 6,
   },
   quickSelectRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- allow users to create and reuse custom tags directly from the tag picker
- add a dedicated subtasks panel with inline previews and list management
- include subtasks and resolved tag labels when emitting the create payload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fed6cf21d883268bc3130e071243cd