### PR TITLE
Add spring snapping to swipeable task cards

### DIFF
--- a/App.js
+++ b/App.js
@@ -1042,9 +1042,20 @@ function SwipeableTaskCard({
   }, [translateX]);
 
   const handlePanRelease = useCallback(() => {
-    const currentValue = Math.min(0, Math.max(-actionWidth, currentOffsetRef.current));
-    translateX.setValue(currentValue);
-    setIsOpen(currentValue <= -actionWidth * 0.35);
+    const clampedValue = Math.min(0, Math.max(-actionWidth, currentOffsetRef.current));
+    const shouldOpen = clampedValue <= -actionWidth * 0.5;
+    const targetValue = shouldOpen ? -actionWidth : 0;
+
+    setIsOpen(shouldOpen);
+    currentOffsetRef.current = targetValue;
+
+    Animated.spring(translateX, {
+      toValue: targetValue,
+      damping: 20,
+      stiffness: 220,
+      mass: 0.9,
+      useNativeDriver: USE_NATIVE_DRIVER,
+    }).start();
   }, [actionWidth, translateX]);
 
   const panResponder = useMemo(


### PR DESCRIPTION
## Summary
- add spring-based snapping so swipeable task cards settle into open or closed states
- clamp swipe offsets and animate to the nearest resting position for smoother interactions

## Testing
- Not run (UI change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179d76fc108326b635dfa4991b1fb5)