### PR TITLE
Fix daily completion and update task editor layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -123,6 +123,27 @@ const formatTaskTime = (time) => {
   return 'Anytime';
 };
 
+const getTaskCompletionStatus = (task, date) => {
+  if (!task || !date) {
+    return false;
+  }
+
+  const dateKey = typeof date === 'string' ? date : getDateKey(date);
+  if (!dateKey) {
+    return false;
+  }
+
+  if (task.completedDates && typeof task.completedDates === 'object') {
+    return Boolean(task.completedDates[dateKey]);
+  }
+
+  if (!task.repeat && task.dateKey) {
+    return task.dateKey === dateKey ? Boolean(task.completed) : false;
+  }
+
+  return false;
+};
+
 const normalizeTaskTagKey = (task) => {
   if (!task) {
     return null;
@@ -313,7 +334,8 @@ function ScheduleApp() {
       date.setDate(base.getDate() + offset);
       const key = getDateKey(date);
       const dayTasks = tasks.filter((task) => shouldTaskAppearOnDate(task, date));
-      const allCompleted = dayTasks.length > 0 && dayTasks.every((task) => task.completed);
+      const allCompleted =
+        dayTasks.length > 0 && dayTasks.every((task) => getTaskCompletionStatus(task, key));
       return {
         date,
         key,
@@ -365,15 +387,34 @@ function ScheduleApp() {
     }
     return tasksForSelectedDate.filter((task) => normalizeTaskTagKey(task) === selectedTagFilter);
   }, [selectedTagFilter, tasksForSelectedDate]);
+  const visibleTasksForSelectedDay = useMemo(
+    () =>
+      visibleTasks.map((task) => ({
+        ...task,
+        completed: getTaskCompletionStatus(task, selectedDateKey),
+      })),
+    [selectedDateKey, visibleTasks]
+  );
   const allTasksCompletedForSelectedDay =
-    tasksForSelectedDate.length > 0 && tasksForSelectedDate.every((task) => task.completed);
+    tasksForSelectedDate.length > 0 &&
+    tasksForSelectedDate.every((task) => getTaskCompletionStatus(task, selectedDateKey));
   const completedTaskCount = useMemo(
-    () => tasksForSelectedDate.filter((task) => task.completed).length,
-    [tasksForSelectedDate]
+    () => tasksForSelectedDate.filter((task) => getTaskCompletionStatus(task, selectedDateKey)).length,
+    [selectedDateKey, tasksForSelectedDate]
   );
   const activeTask = useMemo(
     () => tasks.find((task) => task.id === activeTaskId) ?? null,
     [activeTaskId, tasks]
+  );
+  const activeTaskForSelectedDate = useMemo(
+    () =>
+      activeTask
+        ? {
+            ...activeTask,
+            completed: getTaskCompletionStatus(activeTask, selectedDateKey),
+          }
+        : null,
+    [activeTask, selectedDateKey]
   );
   const lastToggleRef = useRef(0);
   const overlayOpacity = useRef(new Animated.Value(0)).current;
@@ -507,14 +548,35 @@ function ScheduleApp() {
     setSelectedDate(normalized);
   }, []);
 
-  const handleToggleTaskCompletion = useCallback((taskId) => {
-    triggerImpact(Haptics.ImpactFeedbackStyle.Light);
-    setTasks((previous) =>
-      previous.map((task) =>
-        task.id === taskId ? { ...task, completed: !task.completed } : task
-      )
-    );
-  }, []);
+  const handleToggleTaskCompletion = useCallback(
+    (taskId, dateKey = selectedDateKey) => {
+      const targetDateKey = dateKey ?? selectedDateKey;
+      triggerImpact(Haptics.ImpactFeedbackStyle.Light);
+      setTasks((previous) =>
+        previous.map((task) => {
+          if (task.id !== taskId) {
+            return task;
+          }
+
+          const completedDates = { ...(task.completedDates ?? {}) };
+          const isCompletedForDate = getTaskCompletionStatus(task, targetDateKey);
+
+          if (isCompletedForDate) {
+            delete completedDates[targetDateKey];
+          } else if (targetDateKey) {
+            completedDates[targetDateKey] = true;
+          }
+
+          return {
+            ...task,
+            completedDates,
+            completed: Boolean(completedDates[targetDateKey]),
+          };
+        })
+      );
+    },
+    [selectedDateKey]
+  );
 
   const convertSubtasks = useCallback((subtasks, existing = []) => {
     const remainingExisting = [...existing];
@@ -550,6 +612,7 @@ function ScheduleApp() {
       date: normalizedDate,
       dateKey,
       completed: false,
+      completedDates: {},
       subtasks: convertSubtasks(habit?.subtasks ?? []),
       repeat: habit?.repeat,
       reminder: habit?.reminder,
@@ -877,7 +940,7 @@ function ScheduleApp() {
               )}
 
               <View style={styles.tasksSection}>
-                {visibleTasks.length === 0 ? (
+                {visibleTasksForSelectedDay.length === 0 ? (
                   <View style={styles.emptyStateContainer}>
                     <View
                       style={[styles.emptyStateIllustration, dynamicStyles.emptyStateIllustration]}
@@ -894,7 +957,7 @@ function ScheduleApp() {
                     </Text>
                   </View>
                 ) : (
-                  visibleTasks.map((task) => {
+                  visibleTasksForSelectedDay.map((task) => {
                     const backgroundColor = lightenColor(task.color, 0.75);
                     const totalSubtasks = Array.isArray(task.subtasks) ? task.subtasks.length : 0;
                     const completedSubtasks = Array.isArray(task.subtasks)
@@ -909,7 +972,7 @@ function ScheduleApp() {
                         totalSubtasks={totalSubtasks}
                         completedSubtasks={completedSubtasks}
                         onPress={() => setActiveTaskId(task.id)}
-                        onToggleCompletion={() => handleToggleTaskCompletion(task.id)}
+                        onToggleCompletion={() => handleToggleTaskCompletion(task.id, selectedDateKey)}
                         onCopy={() => {
                           const duplicated = {
                             ...task,
@@ -1188,11 +1251,11 @@ function ScheduleApp() {
         )}
       </View>
       <TaskDetailModal
-        visible={Boolean(activeTask)}
-        task={activeTask}
+        visible={Boolean(activeTaskForSelectedDate)}
+        task={activeTaskForSelectedDate}
         onClose={closeTaskDetail}
         onToggleSubtask={handleToggleSubtask}
-        onToggleCompletion={handleToggleTaskCompletion}
+        onToggleCompletion={(taskId) => handleToggleTaskCompletion(taskId, selectedDateKey)}
         onEdit={(taskId) => {
           const taskToEdit = tasks.find((task) => task.id === taskId);
           if (!taskToEdit) {
@@ -1489,23 +1552,15 @@ function TaskDetailModal({
                 ))
               )}
             </ScrollView>
-            <TouchableOpacity
-              style={styles.detailEditButton}
+            <Pressable
+              style={styles.detailEditLink}
               onPress={() => onEdit?.(task.id)}
               accessibilityRole="button"
               accessibilityLabel="Edit task"
             >
               <Ionicons name="create-outline" size={18} color="#3c2ba7" />
               <Text style={styles.detailEditButtonText}>Edit Task</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.detailCloseButton}
-              onPress={onClose}
-              accessibilityRole="button"
-              accessibilityLabel="Close task details"
-            >
-              <Text style={styles.detailCloseButtonText}>Close</Text>
-            </TouchableOpacity>
+            </Pressable>
           </View>
         </View>
       </View>
@@ -1895,28 +1950,14 @@ const styles = StyleSheet.create({
     color: '#6f7a86',
     textDecorationLine: 'line-through',
   },
-  detailEditButton: {
+  detailEditLink: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
     paddingVertical: 12,
-    borderRadius: 16,
-    backgroundColor: '#ffffff',
-    borderWidth: 1,
-    borderColor: '#cfd3eb',
-    marginBottom: 12,
   },
   detailEditButtonText: {
-    fontSize: 15,
-    fontWeight: '600',
-    color: '#3c2ba7',
-  },
-  detailCloseButton: {
-    alignItems: 'center',
-    paddingVertical: 12,
-  },
-  detailCloseButtonText: {
     fontSize: 15,
     fontWeight: '600',
     color: '#3c2ba7',

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -380,9 +380,9 @@ export default function AddHabitSheet({
   const { height } = useWindowDimensions();
   const insets = useSafeAreaInsets();
   const sheetHeight = useMemo(() => {
-    const usableHeight = height - insets.top - insets.bottom;
-    return Math.min(usableHeight * 0.92, usableHeight - 24);
-  }, [height, insets.bottom, insets.top]);
+    const usableHeight = height - insets.top;
+    return usableHeight;
+  }, [height, insets.top]);
   const [title, setTitle] = useState('');
   const [selectedColor, setSelectedColor] = useState(COLORS[0]);
   const [selectedEmoji, setSelectedEmoji] = useState(DEFAULT_EMOJI);
@@ -976,8 +976,9 @@ export default function AddHabitSheet({
       >
         <KeyboardAvoidingView
           style={styles.keyboardAvoiding}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior="padding"
           enabled
+          keyboardVerticalOffset={insets.top}
         >
           <SafeAreaView style={[styles.safeArea, { backgroundColor: sheetBackgroundColor }]}>
             <View style={styles.header}>
@@ -1006,9 +1007,13 @@ export default function AddHabitSheet({
             </View>
             <ScrollView
               style={styles.scrollView}
-              contentContainerStyle={styles.scrollViewContent}
+              contentContainerStyle={[
+                styles.scrollViewContent,
+                { paddingBottom: Math.max(insets.bottom, 24) + 240 },
+              ]}
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="interactive"
             >
               <Pressable
                 style={[styles.emojiButton, isEmojiPickerVisible && styles.emojiButtonActive]}


### PR DESCRIPTION
## Summary
- track task completion per day to avoid marking repeated tasks across all dates
- simplify task detail actions by keeping a single Edit Task entry
- expand the task editor sheet to full height with extra padding for keyboard when adding subtasks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb1cf192483268175121e40c6d380)