### PR TITLE
Add persistent storage for tasks and user settings

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,66 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEYS = {
+  TASKS: '@schedule_app/tasks',
+  SETTINGS: '@schedule_app/settings',
+  HISTORY: '@schedule_app/history',
+};
+
+const parseStoredJson = (value, fallback) => {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.warn('Failed to parse stored data', error);
+    return fallback;
+  }
+};
+
+export async function loadTasks() {
+  const raw = await AsyncStorage.getItem(STORAGE_KEYS.TASKS);
+  return parseStoredJson(raw, []);
+}
+
+export async function saveTasks(tasks) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEYS.TASKS, JSON.stringify(tasks));
+  } catch (error) {
+    console.warn('Failed to save tasks', error);
+  }
+}
+
+export async function loadUserSettings() {
+  const raw = await AsyncStorage.getItem(STORAGE_KEYS.SETTINGS);
+  return parseStoredJson(raw, null);
+}
+
+export async function saveUserSettings(settings) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEYS.SETTINGS, JSON.stringify(settings));
+  } catch (error) {
+    console.warn('Failed to save settings', error);
+  }
+}
+
+export async function loadHistory() {
+  const raw = await AsyncStorage.getItem(STORAGE_KEYS.HISTORY);
+  return parseStoredJson(raw, []);
+}
+
+export async function saveHistory(history) {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEYS.HISTORY, JSON.stringify(history));
+  } catch (error) {
+    console.warn('Failed to save history', error);
+  }
+}
+
+export async function resetStorage() {
+  try {
+    await AsyncStorage.multiRemove(Object.values(STORAGE_KEYS));
+  } catch (error) {
+    console.warn('Failed to reset storage', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage-backed storage helpers for tasks, user settings, and history
- hydrate application state from storage and persist updates for tasks and preferences
- record task and subtask activity in a history log for future use

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca661f91c8326a72d1476d09bddc5)