### PR TITLE
Set Android navigation bar to black

### DIFF
--- a/App.js
+++ b/App.js
@@ -94,16 +94,16 @@ const NAV_BAR_THEMES = {
     buttonStyle: 'light',
   },
   calendar: {
-    backgroundColor: '#f6f6fb',
-    buttonStyle: 'dark',
+    backgroundColor: '#000000',
+    buttonStyle: 'light',
   },
   discover: {
-    backgroundColor: '#f6f6fb',
-    buttonStyle: 'dark',
+    backgroundColor: '#000000',
+    buttonStyle: 'light',
   },
   profile: {
-    backgroundColor: '#f6f6fb',
-    buttonStyle: 'dark',
+    backgroundColor: '#000000',
+    buttonStyle: 'light',
   },
 };
 
@@ -1111,7 +1111,11 @@ function ScheduleApp() {
         },
       ]}
     >
-      <StatusBar barStyle="light-content" backgroundColor="#000" />
+      <StatusBar
+        barStyle="dark-content"
+        backgroundColor="transparent"
+        translucent
+      />
 
       <View style={styles.container}>
         <View
@@ -1918,11 +1922,11 @@ const styles = StyleSheet.create({
   },
   safeArea: {
     flex: 1,
-    backgroundColor: '#000',
+    backgroundColor: '#f6f6fb',
   },
   appFrame: {
     flex: 1,
-    backgroundColor: '#000',
+    backgroundColor: '#f6f6fb',
   },
   content: {
     flex: 1,
@@ -2325,6 +2329,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 12,
     elevation: 8,
+    borderTopWidth: 0,
   },
   bottomBarDimmed: {
     opacity: 0.4,
@@ -2350,7 +2355,7 @@ const styles = StyleSheet.create({
     color: '#3c2ba7',
   },
   inactiveColor: {
-    color: '#9ba0b0',
+    color: '#888888',
   },
   addButton: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- update Android navigation bar theme to use a black background with light buttons
- keep the bottom tab bar styling white with purple active and gray inactive states

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208d0079808326a312cac0a0bf2573)