### PR TITLE
Set nav bar themes to light background

### DIFF
--- a/App.js
+++ b/App.js
@@ -90,8 +90,8 @@ const RIGHT_TABS = [
 
 const NAV_BAR_THEMES = {
   today: {
-    backgroundColor: '#000000',
-    buttonStyle: 'light',
+    backgroundColor: '#f6f6fb', // Cor de fundo da tela (quase branco)
+    buttonStyle: 'dark', // Botões do Android escuros para aparecer no fundo claro
   },
   calendar: {
     backgroundColor: '#f6f6fb',
@@ -747,22 +747,13 @@ function ScheduleApp() {
     }
 
     const theme = getNavigationBarThemeForTab(tabKey);
-    let isRelativePosition = false;
-
     try {
       await NavigationBar.setPositionAsync('relative');
-      if (NavigationBar.getPositionAsync) {
-        const position = await NavigationBar.getPositionAsync();
-        isRelativePosition = position === 'relative';
-      }
-      if (!NavigationBar.getPositionAsync) {
-        isRelativePosition = true;
-      }
     } catch (error) {
       // Ignore when navigation bar position can't be updated
     }
 
-    if (isRelativePosition && NavigationBar.setBackgroundColorAsync) {
+    if (NavigationBar.setBackgroundColorAsync) {
       try {
         await NavigationBar.setBackgroundColorAsync(theme.backgroundColor);
       } catch (error) {
@@ -1111,7 +1102,11 @@ function ScheduleApp() {
         },
       ]}
     >
-      <StatusBar barStyle="light-content" backgroundColor="#000" />
+      <StatusBar
+        barStyle="dark-content"
+        backgroundColor="transparent"
+        translucent
+      />
 
       <View style={styles.container}>
         <View
@@ -1918,11 +1913,11 @@ const styles = StyleSheet.create({
   },
   safeArea: {
     flex: 1,
-    backgroundColor: '#000',
+    backgroundColor: '#f6f6fb',
   },
   appFrame: {
     flex: 1,
-    backgroundColor: '#000',
+    backgroundColor: '#f6f6fb',
   },
   content: {
     flex: 1,
@@ -2325,6 +2320,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 12,
     elevation: 8,
+    borderTopWidth: 0,
   },
   bottomBarDimmed: {
     opacity: 0.4,
@@ -2350,7 +2346,7 @@ const styles = StyleSheet.create({
     color: '#3c2ba7',
   },
   inactiveColor: {
-    color: '#9ba0b0',
+    color: '#888888',
   },
   addButton: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- switch navigation bar themes to use the light screen background with dark buttons on all tabs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69208d0079808326a312cac0a0bf2573)