### PR TITLE
Add custom image selection to habit sheet

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -3,6 +3,7 @@ import {
   AccessibilityInfo,
   Animated,
   BackHandler,
+  Image,
   KeyboardAvoidingView,
   PanResponder,
   Platform,
@@ -18,6 +19,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
+import * as ImagePicker from 'expo-image-picker';
 
 const SHEET_OPEN_DURATION = 300;
 const SHEET_CLOSE_DURATION = 220;
@@ -395,6 +397,8 @@ export default function AddHabitSheet({
   const [pendingReminder, setPendingReminder] = useState(reminderOption);
   const [pendingTag, setPendingTag] = useState(selectedTag);
   const [pendingSubtasks, setPendingSubtasks] = useState([]);
+  const [customImage, setCustomImage] = useState(null);
+  const [isLoadingImage, setIsLoadingImage] = useState(false);
   const titleInputRef = useRef(null);
   const translateY = useRef(new Animated.Value(sheetHeight || height)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
@@ -456,6 +460,35 @@ export default function AddHabitSheet({
 
   const handleToggleEmojiPicker = useCallback(() => {
     setEmojiPickerVisible((prev) => !prev);
+  }, []);
+
+  const handlePickImage = useCallback(async () => {
+    if (isLoadingImage) {
+      return;
+    }
+
+    try {
+      setIsLoadingImage(true);
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsEditing: true,
+        aspect: [1, 1],
+        quality: 1,
+      });
+
+      if (!result.canceled && result.assets?.length) {
+        setCustomImage(result.assets[0].uri);
+        setEmojiPickerVisible(false);
+      }
+    } catch (error) {
+      console.error('Error selecting custom image:', error);
+    } finally {
+      setIsLoadingImage(false);
+    }
+  }, [isLoadingImage]);
+
+  const handleRemoveCustomImage = useCallback(() => {
+    setCustomImage(null);
   }, []);
 
   const handleOpenPanel = useCallback(
@@ -639,6 +672,7 @@ export default function AddHabitSheet({
     setSelectedTag(resolvedTagKey);
     setPendingTag(resolvedTagKey);
     setSubtasks(resolvedSubtasks);
+    setCustomImage(initialHabit.customImage ?? null);
 
     setCalendarMonthState(new Date(resolvedStartDate.getFullYear(), resolvedStartDate.getMonth(), 1));
     setPendingDate(resolvedStartDate);
@@ -719,6 +753,8 @@ export default function AddHabitSheet({
           setTagOptions([...DEFAULT_TAG_OPTIONS]);
           setPendingTag('none');
           setSubtasks([]);
+          setCustomImage(null);
+          setIsLoadingImage(false);
         }
       });
     }
@@ -769,6 +805,7 @@ export default function AddHabitSheet({
       title: title.trim(),
       color: selectedColor,
       emoji: selectedEmoji,
+      customImage,
       startDate,
       repeat: { option: repeatOption, weekdays: Array.from(selectedWeekdays) },
       time: {
@@ -806,6 +843,7 @@ export default function AddHabitSheet({
     title,
     reminderOption,
     subtasks,
+    customImage,
     tagOptions,
   ]);
 
@@ -1008,12 +1046,16 @@ export default function AddHabitSheet({
               <Pressable
                 style={[styles.emojiButton, isEmojiPickerVisible && styles.emojiButtonActive]}
                 accessibilityRole="button"
-                accessibilityLabel={`Choose emoji, currently ${selectedEmoji}`}
+                accessibilityLabel={`Choose icon, currently ${customImage ? 'custom image' : selectedEmoji}`}
                 accessibilityHint="Opens a list of emoji options"
                 onPress={handleToggleEmojiPicker}
                 hitSlop={12}
               >
-                <Text style={styles.emoji}>{selectedEmoji}</Text>
+                {customImage ? (
+                  <Image source={{ uri: customImage }} style={styles.customIconImage} />
+                ) : (
+                  <Text style={styles.emoji}>{selectedEmoji}</Text>
+                )}
                 <Ionicons
                   name={isEmojiPickerVisible ? 'chevron-up' : 'chevron-down'}
                   size={18}
@@ -1023,6 +1065,27 @@ export default function AddHabitSheet({
               </Pressable>
               {isEmojiPickerVisible && (
                 <View style={styles.emojiPicker}>
+                  <Pressable
+                    style={[styles.emojiOption, styles.emojiUploadOption]}
+                    onPress={handlePickImage}
+                    accessibilityRole="button"
+                    accessibilityLabel="Upload custom image"
+                    accessibilityHint="Opens your gallery to choose an image"
+                    disabled={isLoadingImage}
+                  >
+                    <Ionicons name="image-outline" size={24} color="#1F2742" />
+                  </Pressable>
+                  {customImage && (
+                    <Pressable
+                      style={[styles.emojiOption, styles.emojiOptionSelected]}
+                      onPress={handleRemoveCustomImage}
+                      accessibilityRole="button"
+                      accessibilityLabel="Remove custom image"
+                      accessibilityHint="Revert to emoji icon"
+                    >
+                      <Ionicons name="close" size={20} color="#1F2742" />
+                    </Pressable>
+                  )}
                   {EMOJIS.map((emoji) => {
                     const isSelected = selectedEmoji === emoji;
                     return (
@@ -2130,6 +2193,12 @@ const styles = StyleSheet.create({
     // shadowRadius: 16,
     // elevation: 6,
   },
+  customIconImage: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    resizeMode: 'cover',
+  },
   emoji: {
     fontSize: 52,
     textAlign: 'center',
@@ -2151,6 +2220,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: '#F2F6FF',
+  },
+  emojiUploadOption: {
+    backgroundColor: '#E7F0FF',
   },
   emojiOptionSelected: {
     backgroundColor: '#DDE9FF',


### PR DESCRIPTION
## Summary
- allow choosing custom images for habit icons via the emoji picker menu
- persist selected custom images through habit creation and editing payloads
- add UI styling to display uploaded icons and remove them when desired

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69385f483c98832693fb6326c214cb26)