### PR TITLE
Ensure task names are unique and refine repeat layout

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -2977,11 +2977,12 @@ const styles = StyleSheet.create({
   repeatPanel: {
     backgroundColor: '#F5F7FF',
     borderRadius: 20,
-    paddingVertical: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 12,
   },
   repeatContent: {
     gap: 18,
-    marginTop: 12,
   },
   weekdayToggleRow: {
     flexDirection: 'row',
@@ -3071,8 +3072,10 @@ const styles = StyleSheet.create({
     gap: 18,
   },
   intervalSection: {
-    marginTop: 6,
+    marginTop: 10,
     gap: 12,
+    paddingHorizontal: 4,
+    paddingVertical: 2,
   },
   intervalRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- enforce unique task titles by adding numeric suffixes when duplicates are created or updated
- persist updated task titles in history entries
- apply additional padding and spacing to the repeat panel for a more harmonious layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c1396691c8326861265b6b4e777a1)