### PR TITLE
Add quantity task type with adjustable progress

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -98,3 +98,26 @@ export async function resetStorage() {
     console.warn('Failed to reset storage', error);
   }
 }
+
+export async function saveTask(text, category, type = 'standard', targetValue = 0) {
+  try {
+    const existingTasks = await loadTasks();
+    const newTask = {
+      id: Date.now().toString(),
+      text,
+      category,
+      type,
+      completed: false,
+      subtasks: type === 'standard' ? [] : undefined,
+      targetValue: type === 'quantity' ? parseFloat(targetValue) || 0 : undefined,
+      currentValue: type === 'quantity' ? 0 : undefined,
+    };
+
+    const updatedTasks = [...existingTasks, newTask];
+    await AsyncStorage.setItem(STORAGE_KEYS.TASKS, JSON.stringify(updatedTasks));
+    return updatedTasks;
+  } catch (error) {
+    console.warn('Failed to save task', error);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add quantity task type options when creating or editing habits, including target values
- render quantity tasks with a dedicated water-style progress card and editing modal
- update storage and completion logic to handle quantity targets and adjustable progress

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941521be2648326a5ba1a33e71acc45)