### PR TITLE
Sync quantum progress completion with daily status and add quantum adjustment UI

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,6 +13,7 @@ import {
   StatusBar,
   StyleSheet,
   Text,
+  TextInput,
   FlatList,
   TouchableOpacity,
   View,
@@ -427,6 +428,52 @@ const formatTaskTime = (time) => {
   return 'Anytime';
 };
 
+const clampValue = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const formatDuration = (totalSeconds) => {
+  const safeSeconds = Math.max(0, totalSeconds || 0);
+  const minutes = Math.floor(safeSeconds / 60);
+  const seconds = safeSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+};
+
+const getQuantumProgressLabel = (task) => {
+  if (!task || task.type !== 'quantum' || !task.quantum) {
+    return null;
+  }
+  const mode = task.quantum.mode;
+  if (mode === 'timer') {
+    const minutes = task.quantum.timer?.minutes ?? 0;
+    const seconds = task.quantum.timer?.seconds ?? 0;
+    const limitSeconds = minutes * 60 + seconds;
+    if (!limitSeconds) {
+      return null;
+    }
+    const doneSeconds =
+      typeof task.quantum.doneSeconds === 'number'
+        ? task.quantum.doneSeconds
+        : task.completed
+        ? limitSeconds
+        : 0;
+    return `${formatDuration(doneSeconds)}/${formatDuration(limitSeconds)}`;
+  }
+  if (mode === 'count') {
+    const limitValue = task.quantum.count?.value ?? 0;
+    if (!limitValue) {
+      return null;
+    }
+    const unit = task.quantum.count?.unit?.trim() ?? '';
+    const doneValue =
+      typeof task.quantum.doneCount === 'number'
+        ? task.quantum.doneCount
+        : task.completed
+        ? limitValue
+        : 0;
+    return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
+  }
+  return null;
+};
+
 const getTaskCompletionStatus = (task, date) => {
   if (!task || !date) {
     return false;
@@ -761,6 +808,7 @@ function DayReportModal({ visible, date, tasks, onClose, customImages }) {
                   {tasks.map((task, index) => {
                     const baseColor = task.color || '#3c2ba7';
                     const lightBg = lightenColor(baseColor, 0.85);
+                    const quantumLabel = getQuantumProgressLabel(task);
 
                     return (
                       <View
@@ -796,11 +844,15 @@ function DayReportModal({ visible, date, tasks, onClose, customImages }) {
                             {task.title}
                           </Text>
 
-                          {task.totalSubtasks > 0 && (
+                          {quantumLabel ? (
+                            <Text style={{ fontSize: 12, color: '#666', marginTop: 2 }}>
+                              {quantumLabel}
+                            </Text>
+                          ) : task.totalSubtasks > 0 ? (
                             <Text style={{ fontSize: 12, color: '#666', marginTop: 2 }}>
                               {task.completedSubtasks}/{task.totalSubtasks} subtasks
                             </Text>
-                          )}
+                          ) : null}
                         </View>
 
                         {task.completed ? (
@@ -845,6 +897,10 @@ function ScheduleApp() {
   const [tasks, setTasks] = useState([]);
   const [reportDate, setReportDate] = useState(null);
   const [activeTaskId, setActiveTaskId] = useState(null);
+  const [quantumAdjustTaskId, setQuantumAdjustTaskId] = useState(null);
+  const [quantumAdjustMinutes, setQuantumAdjustMinutes] = useState('0');
+  const [quantumAdjustSeconds, setQuantumAdjustSeconds] = useState('0');
+  const [quantumAdjustCount, setQuantumAdjustCount] = useState('1');
   const [selectedTagFilter, setSelectedTagFilter] = useState(
     DEFAULT_USER_SETTINGS.selectedTagFilter
   );
@@ -1123,6 +1179,123 @@ function ScheduleApp() {
           }
         : null,
     [activeTask, selectedDateKey]
+  );
+
+  const openQuantumAdjust = useCallback((task) => {
+    if (!task || task.type !== 'quantum') {
+      return;
+    }
+    setQuantumAdjustTaskId(task.id);
+    if (task.quantum?.mode === 'timer') {
+      setQuantumAdjustMinutes('0');
+      setQuantumAdjustSeconds('0');
+    } else {
+      setQuantumAdjustCount('1');
+    }
+  }, []);
+
+  const closeQuantumAdjust = useCallback(() => {
+    setQuantumAdjustTaskId(null);
+  }, []);
+
+  const handleQuantumAdjustment = useCallback(
+    (direction) => {
+      if (!quantumAdjustTaskId) {
+        return;
+      }
+      const targetTask = tasks.find((task) => task.id === quantumAdjustTaskId);
+      if (!targetTask) {
+        return;
+      }
+      const mode = targetTask.quantum?.mode;
+      const dateKey = selectedDateKey;
+      setTasks((previous) =>
+        previous.map((task) => {
+          if (task.id !== quantumAdjustTaskId) {
+            return task;
+          }
+          if (mode === 'timer') {
+            const minutes = Number.parseInt(quantumAdjustMinutes, 10) || 0;
+            const seconds = Number.parseInt(quantumAdjustSeconds, 10) || 0;
+            const deltaSeconds = minutes * 60 + seconds;
+            if (!deltaSeconds) {
+              return task;
+            }
+            const limitSeconds =
+              (task.quantum?.timer?.minutes ?? 0) * 60 + (task.quantum?.timer?.seconds ?? 0);
+            if (!limitSeconds) {
+              return task;
+            }
+            const currentSeconds = task.quantum?.doneSeconds ?? 0;
+            const nextSeconds = clampValue(
+              currentSeconds + direction * deltaSeconds,
+              0,
+              limitSeconds
+            );
+            const completedDates = dateKey
+              ? { ...(task.completedDates ?? {}) }
+              : task.completedDates;
+            if (dateKey) {
+              if (nextSeconds === limitSeconds) {
+                completedDates[dateKey] = true;
+              } else {
+                delete completedDates[dateKey];
+              }
+            }
+            return {
+              ...task,
+              completed: nextSeconds === limitSeconds,
+              completedDates,
+              quantum: {
+                ...task.quantum,
+                doneSeconds: nextSeconds,
+              },
+            };
+          }
+          const deltaCount = Number.parseInt(quantumAdjustCount, 10) || 0;
+          if (!deltaCount) {
+            return task;
+          }
+          const limitCount = task.quantum?.count?.value ?? 0;
+          if (!limitCount) {
+            return task;
+          }
+          const currentCount = task.quantum?.doneCount ?? 0;
+          const nextCount = clampValue(
+            currentCount + direction * deltaCount,
+            0,
+            limitCount
+          );
+          const completedDates = dateKey
+            ? { ...(task.completedDates ?? {}) }
+            : task.completedDates;
+          if (dateKey) {
+            if (nextCount === limitCount) {
+              completedDates[dateKey] = true;
+            } else {
+              delete completedDates[dateKey];
+            }
+          }
+          return {
+            ...task,
+            completed: nextCount === limitCount,
+            completedDates,
+            quantum: {
+              ...task.quantum,
+              doneCount: nextCount,
+            },
+          };
+        })
+      );
+    },
+    [
+      quantumAdjustCount,
+      quantumAdjustMinutes,
+      quantumAdjustSeconds,
+      quantumAdjustTaskId,
+      selectedDateKey,
+      tasks,
+    ]
   );
   const lastToggleRef = useRef(0);
   const overlayOpacity = useRef(new Animated.Value(0)).current;
@@ -1538,6 +1711,9 @@ function ScheduleApp() {
       reminder: habit?.reminder,
       tag: habit?.tag,
       tagLabel: habit?.tagLabel,
+      type: habit?.type,
+      typeLabel: habit?.typeLabel,
+      quantum: habit?.quantum,
     };
     setTasks((previous) => [...previous, newTask]);
     setSelectedDate(normalizedDate);
@@ -1578,6 +1754,9 @@ function ScheduleApp() {
             reminder: habit?.reminder,
             tag: habit?.tag,
             tagLabel: habit?.tagLabel,
+            type: habit?.type,
+            typeLabel: habit?.typeLabel,
+            quantum: habit?.quantum,
             date: nextDate,
             dateKey: getDateKey(nextDate),
           };
@@ -1945,6 +2124,7 @@ function ScheduleApp() {
                         completedSubtasks={task.completedSubtasks}
                         onPress={() => setActiveTaskId(task.id)}
                         onToggleCompletion={() => handleToggleTaskCompletion(task.id, selectedDateKey)}
+                        onAdjustQuantum={() => openQuantumAdjust(task)}
                         onCopy={() => {
                           const duplicated = {
                             ...task,
@@ -2339,6 +2519,19 @@ function ScheduleApp() {
         mode={habitSheetMode}
         initialHabit={habitSheetInitialTask}
       />
+      <QuantumAdjustModal
+        task={tasks.find((task) => task.id === quantumAdjustTaskId) ?? null}
+        visible={!!quantumAdjustTaskId}
+        minutesValue={quantumAdjustMinutes}
+        secondsValue={quantumAdjustSeconds}
+        countValue={quantumAdjustCount}
+        onChangeMinutes={setQuantumAdjustMinutes}
+        onChangeSeconds={setQuantumAdjustSeconds}
+        onChangeCount={setQuantumAdjustCount}
+        onAdd={() => handleQuantumAdjustment(1)}
+        onSubtract={() => handleQuantumAdjustment(-1)}
+        onClose={closeQuantumAdjust}
+      />
       <CustomizeCalendarModal
         visible={isCustomizeCalendarOpen}
         onClose={() => setCustomizeCalendarOpen(false)}
@@ -2357,6 +2550,7 @@ function SwipeableTaskCard({
   completedSubtasks,
   onPress,
   onToggleCompletion,
+  onAdjustQuantum,
   onCopy,
   onDelete,
   onEdit,
@@ -2444,11 +2638,18 @@ function SwipeableTaskCard({
   );
 
   const totalLabel = useMemo(() => {
+    const quantumLabel = getQuantumProgressLabel(task);
+    if (quantumLabel) {
+      return quantumLabel;
+    }
     if (!totalSubtasks) {
       return null;
     }
     return `${completedSubtasks}/${totalSubtasks}`;
-  }, [completedSubtasks, totalSubtasks]);
+  }, [completedSubtasks, task, totalSubtasks]);
+
+  const isQuantum = task.type === 'quantum';
+  const toggleAction = isQuantum ? onAdjustQuantum : onToggleCompletion;
 
   return (
     <View style={styles.swipeableWrapper}>
@@ -2507,13 +2708,23 @@ function SwipeableTaskCard({
           </View>
         </Pressable>
         <Pressable
-          onPress={() => handleAction(onToggleCompletion)}
-          style={[styles.taskToggle, task.completed && styles.taskToggleCompleted]}
-          accessibilityRole="checkbox"
-          accessibilityLabel={task.completed ? 'Mark task as incomplete' : 'Mark task as complete'}
-          accessibilityState={{ checked: task.completed }}
+          onPress={() => handleAction(toggleAction)}
+          style={[styles.taskToggle, !isQuantum && task.completed && styles.taskToggleCompleted]}
+          accessibilityRole={isQuantum ? 'button' : 'checkbox'}
+          accessibilityLabel={
+            isQuantum
+              ? 'Adjust quantum progress'
+              : task.completed
+              ? 'Mark task as incomplete'
+              : 'Mark task as complete'
+          }
+          accessibilityState={isQuantum ? undefined : { checked: task.completed }}
         >
-          {task.completed && <Ionicons name="checkmark" size={18} color="#ffffff" />}
+          {isQuantum ? (
+            <Ionicons name="add" size={18} color="#1F2742" />
+          ) : (
+            task.completed && <Ionicons name="checkmark" size={18} color="#ffffff" />
+          )}
         </Pressable>
       </Animated.View>
     </View>
@@ -2537,6 +2748,7 @@ function TaskDetailModal({
   const completedSubtasks = Array.isArray(task.subtasks)
     ? task.subtasks.filter((item) => getSubtaskCompletionStatus(item, dateKey)).length
     : 0;
+  const quantumLabel = getQuantumProgressLabel(task);
   const cardBackground = lightenColor(task.color, 0.85);
 
   return (
@@ -2560,11 +2772,13 @@ function TaskDetailModal({
                 <View style={styles.detailTitleContainer}>
                   <Text style={styles.detailTitle}>{task.title}</Text>
                   <Text style={styles.detailTime}>{formatTaskTime(task.time)}</Text>
-                  {totalSubtasks > 0 && (
+                  {quantumLabel ? (
+                    <Text style={styles.detailSubtaskSummaryLabel}>{quantumLabel}</Text>
+                  ) : totalSubtasks > 0 ? (
                     <Text style={styles.detailSubtaskSummaryLabel}>
                       {completedSubtasks}/{totalSubtasks} subtasks completed
                     </Text>
-                  )}
+                  ) : null}
                 </View>
               </View>
               <Pressable
@@ -2630,6 +2844,139 @@ function TaskDetailModal({
             >
               <Ionicons name="create-outline" size={18} color="#3c2ba7" />
               <Text style={styles.detailEditButtonText}>Edit Task</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function QuantumAdjustModal({
+  task,
+  visible,
+  minutesValue,
+  secondsValue,
+  countValue,
+  onChangeMinutes,
+  onChangeSeconds,
+  onChangeCount,
+  onAdd,
+  onSubtract,
+  onClose,
+}) {
+  if (!visible || !task) {
+    return null;
+  }
+
+  const isTimer = task.quantum?.mode === 'timer';
+  const limitLabel = getQuantumProgressLabel(task);
+  const handleMinutesChange = useCallback(
+    (value) => {
+      onChangeMinutes(value.replace(/\D/g, '').slice(0, 2));
+    },
+    [onChangeMinutes]
+  );
+  const handleSecondsChange = useCallback(
+    (value) => {
+      onChangeSeconds(value.replace(/\D/g, '').slice(0, 2));
+    },
+    [onChangeSeconds]
+  );
+  const handleCountChange = useCallback(
+    (value) => {
+      onChangeCount(value.replace(/\D/g, '').slice(0, 4));
+    },
+    [onChangeCount]
+  );
+  const disableActions = isTimer
+    ? (Number.parseInt(minutesValue, 10) || 0) * 60 + (Number.parseInt(secondsValue, 10) || 0) <= 0
+    : (Number.parseInt(countValue, 10) || 0) <= 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.quantumModalOverlay}>
+        <Pressable style={styles.quantumModalBackdrop} onPress={onClose} accessibilityRole="button" />
+        <View style={styles.quantumModalCard}>
+          <View style={styles.quantumModalHeader}>
+            <Text style={styles.quantumModalTitle}>
+              {isTimer ? 'Adjust timer' : 'Adjust count'}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close adjust dialog"
+              hitSlop={8}
+            >
+              <Ionicons name="close" size={20} color="#1F2742" />
+            </Pressable>
+          </View>
+          {limitLabel && (
+            <Text style={styles.quantumModalSubtitle}>Current: {limitLabel}</Text>
+          )}
+          {isTimer ? (
+            <View style={styles.quantumModalRow}>
+              <View style={styles.quantumModalField}>
+                <Text style={styles.quantumModalFieldLabel}>Min</Text>
+                <TextInput
+                  style={styles.quantumModalInput}
+                  value={minutesValue}
+                  onChangeText={handleMinutesChange}
+                  keyboardType="number-pad"
+                  maxLength={2}
+                  placeholder="0"
+                  placeholderTextColor="#9AA5B5"
+                />
+              </View>
+              <View style={styles.quantumModalField}>
+                <Text style={styles.quantumModalFieldLabel}>Sec</Text>
+                <TextInput
+                  style={styles.quantumModalInput}
+                  value={secondsValue}
+                  onChangeText={handleSecondsChange}
+                  keyboardType="number-pad"
+                  maxLength={2}
+                  placeholder="0"
+                  placeholderTextColor="#9AA5B5"
+                />
+              </View>
+            </View>
+          ) : (
+            <View style={styles.quantumModalRow}>
+              <View style={styles.quantumModalField}>
+                <Text style={styles.quantumModalFieldLabel}>Amount</Text>
+                <TextInput
+                  style={styles.quantumModalInput}
+                  value={countValue}
+                  onChangeText={handleCountChange}
+                  keyboardType="number-pad"
+                  maxLength={4}
+                  placeholder="0"
+                  placeholderTextColor="#9AA5B5"
+                />
+              </View>
+            </View>
+          )}
+          <View style={styles.quantumModalActions}>
+            <Pressable
+              style={[styles.quantumModalButton, styles.quantumModalButtonSubtract, disableActions && styles.quantumModalButtonDisabled]}
+              onPress={onSubtract}
+              disabled={disableActions}
+              accessibilityRole="button"
+              accessibilityLabel="Subtract from progress"
+            >
+              <Text style={styles.quantumModalButtonText}>-</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.quantumModalButton, styles.quantumModalButtonAdd, disableActions && styles.quantumModalButtonDisabled]}
+              onPress={onAdd}
+              disabled={disableActions}
+              accessibilityRole="button"
+              accessibilityLabel="Add to progress"
+            >
+              <Text style={[styles.quantumModalButtonText, styles.quantumModalButtonTextLight]}>
+                +
+              </Text>
             </Pressable>
           </View>
         </View>
@@ -3031,6 +3378,96 @@ const styles = StyleSheet.create({
   detailEmptySubtasks: {
     fontSize: 14,
     color: '#6f7a86',
+  },
+  quantumModalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(15, 23, 42, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  quantumModalBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  quantumModalCard: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 24,
+    padding: 20,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.1,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  quantumModalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  quantumModalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1F2742',
+  },
+  quantumModalSubtitle: {
+    marginTop: 8,
+    fontSize: 14,
+    color: '#7F8A9A',
+  },
+  quantumModalRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 16,
+  },
+  quantumModalField: {
+    flex: 1,
+    gap: 6,
+  },
+  quantumModalFieldLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#7F8A9A',
+  },
+  quantumModalInput: {
+    backgroundColor: '#F4F6FB',
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    textAlign: 'center',
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1F2742',
+  },
+  quantumModalActions: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 20,
+  },
+  quantumModalButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  quantumModalButtonAdd: {
+    backgroundColor: '#1F2742',
+  },
+  quantumModalButtonSubtract: {
+    backgroundColor: '#EEF3FF',
+  },
+  quantumModalButtonText: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1F2742',
+  },
+  quantumModalButtonTextLight: {
+    color: '#FFFFFF',
+  },
+  quantumModalButtonDisabled: {
+    opacity: 0.5,
   },
   detailSubtaskRow: {
     flexDirection: 'row',

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -107,6 +107,17 @@ const DEFAULT_TAG_OPTIONS = [
   { key: 'workout', label: 'Workout' },
 ];
 
+const DEFAULT_TYPE_OPTIONS = [
+  { key: 'default', label: 'Defaut' },
+  { key: 'quantum', label: 'Quantum' },
+  { key: 'list', label: 'List' },
+];
+
+const QUANTUM_MODES = [
+  { key: 'timer', label: 'Timer' },
+  { key: 'count', label: 'Count' },
+];
+
 const createTagKey = (label, existingKeys) => {
   const sanitized = label
     .toLowerCase()
@@ -436,6 +447,12 @@ export default function AddHabitSheet({
   const [reminderOption, setReminderOption] = useState('none');
   const [tagOptions, setTagOptions] = useState(() => [...DEFAULT_TAG_OPTIONS]);
   const [selectedTag, setSelectedTag] = useState('none');
+  const [selectedType, setSelectedType] = useState(DEFAULT_TYPE_OPTIONS[0].key);
+  const [quantumMode, setQuantumMode] = useState(QUANTUM_MODES[0].key);
+  const [quantumTimerMinutes, setQuantumTimerMinutes] = useState('0');
+  const [quantumTimerSeconds, setQuantumTimerSeconds] = useState('0');
+  const [quantumCountValue, setQuantumCountValue] = useState('1');
+  const [quantumCountUnit, setQuantumCountUnit] = useState('');
   const [subtasks, setSubtasks] = useState([]);
 
   const [calendarMonth, setCalendarMonthState] = useState(
@@ -455,6 +472,12 @@ export default function AddHabitSheet({
   const [pendingPeriodTime, setPendingPeriodTime] = useState(periodTime);
   const [pendingReminder, setPendingReminder] = useState(reminderOption);
   const [pendingTag, setPendingTag] = useState(selectedTag);
+  const [pendingType, setPendingType] = useState(selectedType);
+  const [pendingQuantumMode, setPendingQuantumMode] = useState(quantumMode);
+  const [pendingQuantumTimerMinutes, setPendingQuantumTimerMinutes] = useState(quantumTimerMinutes);
+  const [pendingQuantumTimerSeconds, setPendingQuantumTimerSeconds] = useState(quantumTimerSeconds);
+  const [pendingQuantumCountValue, setPendingQuantumCountValue] = useState(quantumCountValue);
+  const [pendingQuantumCountUnit, setPendingQuantumCountUnit] = useState(quantumCountUnit);
   const [pendingSubtasks, setPendingSubtasks] = useState([]);
   const [customImage, setCustomImage] = useState(null);
   const [isLoadingImage, setIsLoadingImage] = useState(false);
@@ -577,6 +600,13 @@ export default function AddHabitSheet({
         setPendingReminder(reminderOption);
       } else if (panel === 'tag') {
         setPendingTag(selectedTag);
+      } else if (panel === 'type') {
+        setPendingType(selectedType);
+        setPendingQuantumMode(quantumMode);
+        setPendingQuantumTimerMinutes(quantumTimerMinutes);
+        setPendingQuantumTimerSeconds(quantumTimerSeconds);
+        setPendingQuantumCountValue(quantumCountValue);
+        setPendingQuantumCountUnit(quantumCountUnit);
       } else if (panel === 'subtasks') {
         setPendingSubtasks(subtasks);
       }
@@ -586,11 +616,17 @@ export default function AddHabitSheet({
       handlePendingPointTimeChange,
       hasSpecifiedTime,
       subtasks,
+      quantumMode,
+      quantumTimerMinutes,
+      quantumTimerSeconds,
+      quantumCountValue,
+      quantumCountUnit,
       periodTime,
       pointTime,
       reminderOption,
       repeatFrequency,
       selectedTag,
+      selectedType,
       selectedWeekdays,
       selectedMonthDays,
       startDate,
@@ -686,6 +722,26 @@ export default function AddHabitSheet({
     setSelectedTag(pendingTag);
     closePanel();
   }, [closePanel, pendingTag]);
+
+  const handleApplyType = useCallback(() => {
+    setSelectedType(pendingType);
+    if (pendingType === 'quantum') {
+      setQuantumMode(pendingQuantumMode ?? QUANTUM_MODES[0].key);
+      setQuantumTimerMinutes(pendingQuantumTimerMinutes);
+      setQuantumTimerSeconds(pendingQuantumTimerSeconds);
+      setQuantumCountValue(pendingQuantumCountValue);
+      setQuantumCountUnit(pendingQuantumCountUnit);
+    }
+    closePanel();
+  }, [
+    closePanel,
+    pendingQuantumMode,
+    pendingQuantumTimerMinutes,
+    pendingQuantumTimerSeconds,
+    pendingQuantumCountUnit,
+    pendingQuantumCountValue,
+    pendingType,
+  ]);
 
   const handleCreateCustomTag = useCallback(
     (label) => {
@@ -786,6 +842,14 @@ export default function AddHabitSheet({
         };
     const resolvedReminder = initialHabit.reminder ?? 'none';
     const resolvedTagKey = initialHabit.tag ?? 'none';
+    const resolvedTypeKey = initialHabit.type ?? DEFAULT_TYPE_OPTIONS[0].key;
+    const resolvedQuantumMode = initialHabit.quantum?.mode ?? QUANTUM_MODES[0].key;
+    const resolvedQuantumTimer = initialHabit.quantum?.timer ?? {};
+    const resolvedQuantumCount = initialHabit.quantum?.count ?? {};
+    const resolvedQuantumTimerMinutes = `${resolvedQuantumTimer.minutes ?? '0'}`;
+    const resolvedQuantumTimerSeconds = `${resolvedQuantumTimer.seconds ?? '0'}`;
+    const resolvedQuantumCountValue = `${resolvedQuantumCount.value ?? '1'}`;
+    const resolvedQuantumCountUnit = resolvedQuantumCount.unit ?? '';
     const resolvedSubtasks = Array.isArray(initialHabit.subtasks) ? initialHabit.subtasks : [];
 
     setTitle(initialHabit.title ?? '');
@@ -806,6 +870,14 @@ export default function AddHabitSheet({
     setReminderOption(resolvedReminder);
     setSelectedTag(resolvedTagKey);
     setPendingTag(resolvedTagKey);
+    setSelectedType(resolvedTypeKey);
+    setPendingType(resolvedTypeKey);
+    setQuantumMode(resolvedQuantumMode);
+    setPendingQuantumMode(resolvedQuantumMode);
+    setQuantumTimerMinutes(resolvedQuantumTimerMinutes);
+    setQuantumTimerSeconds(resolvedQuantumTimerSeconds);
+    setQuantumCountValue(resolvedQuantumCountValue);
+    setQuantumCountUnit(resolvedQuantumCountUnit);
     setSubtasks(resolvedSubtasks);
     setCustomImage(initialHabit.customImage ?? null);
 
@@ -823,6 +895,10 @@ export default function AddHabitSheet({
     setPendingPointTime(resolvedPoint);
     setPendingPeriodTime(resolvedPeriod);
     setPendingReminder(resolvedReminder);
+    setPendingQuantumTimerMinutes(resolvedQuantumTimerMinutes);
+    setPendingQuantumTimerSeconds(resolvedQuantumTimerSeconds);
+    setPendingQuantumCountValue(resolvedQuantumCountValue);
+    setPendingQuantumCountUnit(resolvedQuantumCountUnit);
     setPendingSubtasks(resolvedSubtasks);
 
     if (initialHabit.tag && initialHabit.tagLabel) {
@@ -833,6 +909,7 @@ export default function AddHabitSheet({
         return [...prev, { key: initialHabit.tag, label: initialHabit.tagLabel }];
       });
     }
+
   }, [initialHabit, visible]);
 
   useEffect(() => {
@@ -898,6 +975,18 @@ export default function AddHabitSheet({
           setSelectedTag('none');
           setTagOptions([...DEFAULT_TAG_OPTIONS]);
           setPendingTag('none');
+          setSelectedType(DEFAULT_TYPE_OPTIONS[0].key);
+          setPendingType(DEFAULT_TYPE_OPTIONS[0].key);
+          setQuantumMode(QUANTUM_MODES[0].key);
+          setPendingQuantumMode(QUANTUM_MODES[0].key);
+          setQuantumTimerMinutes('0');
+          setQuantumTimerSeconds('0');
+          setQuantumCountValue('1');
+          setQuantumCountUnit('');
+          setPendingQuantumTimerMinutes('0');
+          setPendingQuantumTimerSeconds('0');
+          setPendingQuantumCountValue('1');
+          setPendingQuantumCountUnit('');
           setSubtasks([]);
           setCustomImage(null);
           setIsLoadingImage(false);
@@ -947,6 +1036,8 @@ export default function AddHabitSheet({
     }
     const selectedTagOption =
       tagOptions.find((option) => option.key === selectedTag) ?? tagOptions[0];
+    const selectedTypeOption =
+      typeOptions.find((option) => option.key === selectedType) ?? typeOptions[0];
     const payload = {
       title: title.trim(),
       color: selectedColor,
@@ -970,6 +1061,19 @@ export default function AddHabitSheet({
       reminder: reminderOption,
       tag: selectedTagOption.key,
       tagLabel: selectedTagOption.label,
+      type: selectedTypeOption.key,
+      typeLabel: selectedTypeOption.label,
+      quantum: {
+        mode: quantumMode,
+        timer: {
+          minutes: Number.parseInt(quantumTimerMinutes, 10) || 0,
+          seconds: Number.parseInt(quantumTimerSeconds, 10) || 0,
+        },
+        count: {
+          value: Number.parseInt(quantumCountValue, 10) || 0,
+          unit: quantumCountUnit.trim(),
+        },
+      },
       subtasks,
     };
     if (isEditMode) {
@@ -996,6 +1100,12 @@ export default function AddHabitSheet({
     selectedEmoji,
     selectedTag,
     selectedWeekdays,
+    selectedType,
+    quantumMode,
+    quantumTimerMinutes,
+    quantumTimerSeconds,
+    quantumCountValue,
+    quantumCountUnit,
     startDate,
     timeMode,
     title,
@@ -1003,6 +1113,11 @@ export default function AddHabitSheet({
     subtasks,
     customImage,
     tagOptions,
+    typeOptions,
+    pendingQuantumTimerMinutes,
+    pendingQuantumTimerSeconds,
+    pendingQuantumCountValue,
+    pendingQuantumCountUnit,
   ]);
 
   const panResponder = useMemo(
@@ -1127,6 +1242,13 @@ export default function AddHabitSheet({
     const match = tagOptions.find((option) => option.key === selectedTag);
     return match?.label ?? 'No tag';
   }, [selectedTag, tagOptions]);
+
+  const typeOptions = DEFAULT_TYPE_OPTIONS;
+
+  const typeLabel = useMemo(() => {
+    const match = typeOptions.find((option) => option.key === selectedType);
+    return match?.label ?? typeOptions[0].label;
+  }, [selectedType, typeOptions]);
 
   const pendingTimeTitle = useMemo(() => {
     if (!pendingHasSpecifiedTime) {
@@ -1360,10 +1482,34 @@ export default function AddHabitSheet({
                   label="Tag"
                   value={tagLabel}
                   onPress={() => handleOpenPanel('tag')}
+                />
+                <SheetRow
+                  icon={(
+                    <View style={styles.rowIconContainer}>
+                      <Ionicons name="layers-outline" size={22} color="#61708A" />
+                    </View>
+                  )}
+                  label="Type"
+                  value={typeLabel}
+                  onPress={() => handleOpenPanel('type')}
                   isLast
                 />
               </View>
-              <SubtasksPanel value={subtasks} onChange={setSubtasks} />
+              {selectedType === 'quantum' ? (
+                <QuantumPanel
+                  mode={quantumMode}
+                  timerMinutes={quantumTimerMinutes}
+                  timerSeconds={quantumTimerSeconds}
+                  countValue={quantumCountValue}
+                  countUnit={quantumCountUnit}
+                  onChangeTimerMinutes={setQuantumTimerMinutes}
+                  onChangeTimerSeconds={setQuantumTimerSeconds}
+                  onChangeCountValue={setQuantumCountValue}
+                  onChangeCountUnit={setQuantumCountUnit}
+                />
+              ) : (
+                <SubtasksPanel value={subtasks} onChange={setSubtasks} />
+              )}
             </ScrollView>
             {activePanel === 'date' && (
               <OptionOverlay
@@ -1457,7 +1603,7 @@ export default function AddHabitSheet({
                 />
               </OptionOverlay>
             )}
-              {activePanel === 'tag' && (
+            {activePanel === 'tag' && (
                 <OptionOverlay
                   title="Tag"
                 onClose={closePanel}
@@ -1469,6 +1615,61 @@ export default function AddHabitSheet({
                   onSelect={setPendingTag}
                   onCreateTag={handleCreateCustomTag}
                 />
+              </OptionOverlay>
+            )}
+            {activePanel === 'type' && (
+              <OptionOverlay
+                title="Type"
+                onClose={closePanel}
+                onApply={handleApplyType}
+              >
+                <OptionList
+                  options={typeOptions}
+                  selectedKey={pendingType}
+                  onSelect={setPendingType}
+                />
+                {pendingType === 'quantum' && (
+                  <>
+                    <View style={styles.quantumModeRow}>
+                      {QUANTUM_MODES.map((option) => {
+                        const isSelected = pendingQuantumMode === option.key;
+                        return (
+                          <Pressable
+                            key={option.key}
+                            style={[
+                              styles.quantumModeButton,
+                              isSelected && styles.quantumModeButtonSelected,
+                            ]}
+                            onPress={() => setPendingQuantumMode(option.key)}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: isSelected }}
+                          >
+                            <Text
+                              style={[
+                                styles.quantumModeButtonText,
+                                isSelected && styles.quantumModeButtonTextSelected,
+                              ]}
+                            >
+                              {option.label}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                    <QuantumPanel
+                      mode={pendingQuantumMode}
+                      timerMinutes={pendingQuantumTimerMinutes}
+                      timerSeconds={pendingQuantumTimerSeconds}
+                      countValue={pendingQuantumCountValue}
+                      countUnit={pendingQuantumCountUnit}
+                      onChangeTimerMinutes={setPendingQuantumTimerMinutes}
+                      onChangeTimerSeconds={setPendingQuantumTimerSeconds}
+                      onChangeCountValue={setPendingQuantumCountValue}
+                      onChangeCountUnit={setPendingQuantumCountUnit}
+                      showTitle={false}
+                    />
+                  </>
+                )}
               </OptionOverlay>
             )}
           </View>
@@ -1644,6 +1845,109 @@ function TagPanel({ options, selectedKey, onSelect, onCreateTag }) {
           </Text>
         </Pressable>
       </View>
+    </View>
+  );
+}
+
+function normalizeNumericText(value, { max, fallback = '' } = {}) {
+  const sanitized = value.replace(/\D/g, '');
+  if (!sanitized) {
+    return fallback;
+  }
+  let numeric = Number.parseInt(sanitized, 10);
+  if (Number.isNaN(numeric)) {
+    return fallback;
+  }
+  if (typeof max === 'number') {
+    numeric = Math.min(max, numeric);
+  }
+  return `${numeric}`;
+}
+
+function QuantumPanel({
+  mode,
+  timerMinutes,
+  timerSeconds,
+  countValue,
+  countUnit,
+  onChangeTimerMinutes,
+  onChangeTimerSeconds,
+  onChangeCountValue,
+  onChangeCountUnit,
+  showTitle = true,
+}) {
+  const isTimer = mode === 'timer';
+
+  return (
+    <View style={styles.subtasksPanel}>
+      {showTitle ? (
+        <Text style={styles.subtasksTitle}>{isTimer ? 'Timer' : 'Count'}</Text>
+      ) : null}
+      <View style={styles.subtasksCard}>
+        {isTimer ? (
+          <View style={styles.quantumTimerRow}>
+            <View style={styles.quantumField}>
+              <Text style={styles.quantumFieldLabel}>Min</Text>
+              <TextInput
+                style={styles.quantumFieldInput}
+                value={timerMinutes}
+                onChangeText={(value) => onChangeTimerMinutes(normalizeNumericText(value, { max: 99 }))}
+                keyboardType="number-pad"
+                maxLength={2}
+                placeholder="00"
+                placeholderTextColor="#9AA5B5"
+                accessibilityLabel="Timer minutes"
+              />
+            </View>
+            <View style={styles.quantumField}>
+              <Text style={styles.quantumFieldLabel}>Sec</Text>
+              <TextInput
+                style={styles.quantumFieldInput}
+                value={timerSeconds}
+                onChangeText={(value) => onChangeTimerSeconds(normalizeNumericText(value, { max: 59 }))}
+                keyboardType="number-pad"
+                maxLength={2}
+                placeholder="00"
+                placeholderTextColor="#9AA5B5"
+                accessibilityLabel="Timer seconds"
+              />
+            </View>
+          </View>
+        ) : (
+          <View style={styles.quantumCountRow}>
+            <View style={styles.quantumField}>
+              <Text style={styles.quantumFieldLabel}>Count</Text>
+              <TextInput
+                style={styles.quantumFieldInput}
+                value={countValue}
+                onChangeText={(value) => onChangeCountValue(normalizeNumericText(value, { max: 9999 }))}
+                keyboardType="number-pad"
+                maxLength={4}
+                placeholder="0"
+                placeholderTextColor="#9AA5B5"
+                accessibilityLabel="Count value"
+              />
+            </View>
+            <View style={styles.quantumField}>
+              <Text style={styles.quantumFieldLabel}>Unit</Text>
+              <TextInput
+                style={styles.quantumFieldInput}
+                value={countUnit}
+                onChangeText={onChangeCountUnit}
+                maxLength={12}
+                placeholder="Unit"
+                placeholderTextColor="#9AA5B5"
+                accessibilityLabel="Count unit"
+              />
+            </View>
+          </View>
+        )}
+      </View>
+      <Text style={styles.subtasksPanelHint}>
+        {isTimer
+          ? 'Set the timer duration in minutes and seconds.'
+          : 'Set the count and the unit for this habit.'}
+      </Text>
     </View>
   );
 }
@@ -2632,6 +2936,57 @@ const styles = StyleSheet.create({
     shadowRadius: 12,
     elevation: 6,
     overflow: 'hidden',
+  },
+  quantumModeRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 16,
+  },
+  quantumModeButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 16,
+    backgroundColor: '#EEF3FF',
+    alignItems: 'center',
+  },
+  quantumModeButtonSelected: {
+    backgroundColor: '#1F2742',
+  },
+  quantumModeButtonText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#1F2742',
+  },
+  quantumModeButtonTextSelected: {
+    color: '#FFFFFF',
+  },
+  quantumTimerRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  quantumCountRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  quantumField: {
+    flex: 1,
+    gap: 8,
+  },
+  quantumFieldLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#7F8A9A',
+  },
+  quantumFieldInput: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: '#1F2742',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(109, 125, 150, 0.16)',
+    textAlign: 'center',
   },
   row: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
- Ensure `quantum`-type tasks are marked completed when their progress reaches the configured limit and that the per-day `completedDates` map reflects that state.
- Keep the daily checkbox/visual completion in sync when quantum progress is increased or decreased for a selected date.
- Provide a simple in-app way to add/subtract progress for `quantum` tasks in both `timer` and `count` modes.
- Surface readable quantum progress labels in lists, reports and the task detail view for clarity.

### Description
- Update quantum adjustment logic in `App.js` to set or delete `completedDates[selectedDateKey]` and update `completed` when `doneSeconds`/`doneCount` reaches the limit. 
- Add helpers `clampValue`, `formatDuration`, and `getQuantumProgressLabel` and use them to render quantum progress in `SwipeableTaskCard`, `TaskDetailModal`, and `DayReportModal`.
- Implement `QuantumAdjustModal` plus state and handlers (`openQuantumAdjust`, `closeQuantumAdjust`, `handleQuantumAdjustment`, and `quantumAdjust*` state) to let users add/subtract minutes/seconds or counts, and wire the adjust action from the swipe card.
- Extend `AddHabitSheet` with `DEFAULT_TYPE_OPTIONS`, `QUANTUM_MODES`, `QuantumPanel`, `normalizeNumericText`, and include `type`/`typeLabel`/`quantum` fields in created/updated task payloads.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695427fad3f88326bd5c6936c6cc2b99)