### PR TITLE
Add quantum style selection (Defaut, Animation, Water)

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -118,6 +118,12 @@ const QUANTUM_MODES = [
   { key: 'count', label: 'Count' },
 ];
 
+const QUANTUM_STYLE_OPTIONS = [
+  { key: 'defaut', label: 'Defaut' },
+  { key: 'animation', label: 'Animation' },
+  { key: 'water', label: 'Water' },
+];
+
 const createTagKey = (label, existingKeys) => {
   const sanitized = label
     .toLowerCase()
@@ -449,6 +455,7 @@ export default function AddHabitSheet({
   const [selectedTag, setSelectedTag] = useState('none');
   const [selectedType, setSelectedType] = useState(DEFAULT_TYPE_OPTIONS[0].key);
   const [quantumMode, setQuantumMode] = useState(QUANTUM_MODES[0].key);
+  const [quantumStyle, setQuantumStyle] = useState(QUANTUM_STYLE_OPTIONS[0].key);
   const [quantumTimerMinutes, setQuantumTimerMinutes] = useState('0');
   const [quantumTimerSeconds, setQuantumTimerSeconds] = useState('0');
   const [quantumCountValue, setQuantumCountValue] = useState('1');
@@ -474,6 +481,7 @@ export default function AddHabitSheet({
   const [pendingTag, setPendingTag] = useState(selectedTag);
   const [pendingType, setPendingType] = useState(selectedType);
   const [pendingQuantumMode, setPendingQuantumMode] = useState(quantumMode);
+  const [pendingQuantumStyle, setPendingQuantumStyle] = useState(quantumStyle);
   const [pendingQuantumTimerMinutes, setPendingQuantumTimerMinutes] = useState(quantumTimerMinutes);
   const [pendingQuantumTimerSeconds, setPendingQuantumTimerSeconds] = useState(quantumTimerSeconds);
   const [pendingQuantumCountValue, setPendingQuantumCountValue] = useState(quantumCountValue);
@@ -603,6 +611,7 @@ export default function AddHabitSheet({
       } else if (panel === 'type') {
         setPendingType(selectedType);
         setPendingQuantumMode(quantumMode);
+        setPendingQuantumStyle(quantumStyle);
         setPendingQuantumTimerMinutes(quantumTimerMinutes);
         setPendingQuantumTimerSeconds(quantumTimerSeconds);
         setPendingQuantumCountValue(quantumCountValue);
@@ -617,6 +626,7 @@ export default function AddHabitSheet({
       hasSpecifiedTime,
       subtasks,
       quantumMode,
+      quantumStyle,
       quantumTimerMinutes,
       quantumTimerSeconds,
       quantumCountValue,
@@ -727,6 +737,7 @@ export default function AddHabitSheet({
     setSelectedType(pendingType);
     if (pendingType === 'quantum') {
       setQuantumMode(pendingQuantumMode ?? QUANTUM_MODES[0].key);
+      setQuantumStyle(pendingQuantumStyle ?? QUANTUM_STYLE_OPTIONS[0].key);
       setQuantumTimerMinutes(pendingQuantumTimerMinutes);
       setQuantumTimerSeconds(pendingQuantumTimerSeconds);
       setQuantumCountValue(pendingQuantumCountValue);
@@ -736,6 +747,7 @@ export default function AddHabitSheet({
   }, [
     closePanel,
     pendingQuantumMode,
+    pendingQuantumStyle,
     pendingQuantumTimerMinutes,
     pendingQuantumTimerSeconds,
     pendingQuantumCountUnit,
@@ -844,6 +856,8 @@ export default function AddHabitSheet({
     const resolvedTagKey = initialHabit.tag ?? 'none';
     const resolvedTypeKey = initialHabit.type ?? DEFAULT_TYPE_OPTIONS[0].key;
     const resolvedQuantumMode = initialHabit.quantum?.mode ?? QUANTUM_MODES[0].key;
+    const resolvedQuantumStyle =
+      initialHabit.quantum?.style ?? QUANTUM_STYLE_OPTIONS[0].key;
     const resolvedQuantumTimer = initialHabit.quantum?.timer ?? {};
     const resolvedQuantumCount = initialHabit.quantum?.count ?? {};
     const resolvedQuantumTimerMinutes = `${resolvedQuantumTimer.minutes ?? '0'}`;
@@ -873,7 +887,9 @@ export default function AddHabitSheet({
     setSelectedType(resolvedTypeKey);
     setPendingType(resolvedTypeKey);
     setQuantumMode(resolvedQuantumMode);
+    setQuantumStyle(resolvedQuantumStyle);
     setPendingQuantumMode(resolvedQuantumMode);
+    setPendingQuantumStyle(resolvedQuantumStyle);
     setQuantumTimerMinutes(resolvedQuantumTimerMinutes);
     setQuantumTimerSeconds(resolvedQuantumTimerSeconds);
     setQuantumCountValue(resolvedQuantumCountValue);
@@ -978,7 +994,9 @@ export default function AddHabitSheet({
           setSelectedType(DEFAULT_TYPE_OPTIONS[0].key);
           setPendingType(DEFAULT_TYPE_OPTIONS[0].key);
           setQuantumMode(QUANTUM_MODES[0].key);
+          setQuantumStyle(QUANTUM_STYLE_OPTIONS[0].key);
           setPendingQuantumMode(QUANTUM_MODES[0].key);
+          setPendingQuantumStyle(QUANTUM_STYLE_OPTIONS[0].key);
           setQuantumTimerMinutes('0');
           setQuantumTimerSeconds('0');
           setQuantumCountValue('1');
@@ -1065,6 +1083,7 @@ export default function AddHabitSheet({
       typeLabel: selectedTypeOption.label,
       quantum: {
         mode: quantumMode,
+        style: quantumStyle,
         timer: {
           minutes: Number.parseInt(quantumTimerMinutes, 10) || 0,
           seconds: Number.parseInt(quantumTimerSeconds, 10) || 0,
@@ -1102,6 +1121,7 @@ export default function AddHabitSheet({
     selectedWeekdays,
     selectedType,
     quantumMode,
+    quantumStyle,
     quantumTimerMinutes,
     quantumTimerSeconds,
     quantumCountValue,
@@ -1630,6 +1650,32 @@ export default function AddHabitSheet({
                 />
                 {pendingType === 'quantum' && (
                   <>
+                    <View style={styles.quantumModeRow}>
+                      {QUANTUM_STYLE_OPTIONS.map((option) => {
+                        const isSelected = pendingQuantumStyle === option.key;
+                        return (
+                          <Pressable
+                            key={option.key}
+                            style={[
+                              styles.quantumModeButton,
+                              isSelected && styles.quantumModeButtonSelected,
+                            ]}
+                            onPress={() => setPendingQuantumStyle(option.key)}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: isSelected }}
+                          >
+                            <Text
+                              style={[
+                                styles.quantumModeButtonText,
+                                isSelected && styles.quantumModeButtonTextSelected,
+                              ]}
+                            >
+                              {option.label}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
                     <View style={styles.quantumModeRow}>
                       {QUANTUM_MODES.map((option) => {
                         const isSelected = pendingQuantumMode === option.key;


### PR DESCRIPTION
### Motivation
- Add a style selection when creating/editing a `quantum` type habit so users can choose between visual/behavioral styles. 
- Provide the requested options: `Defaut` (selected by default), `Animation` and `Water`.
- Persist the chosen style with the habit so it is retained when editing or saving.

### Description
- Introduce `QUANTUM_STYLE_OPTIONS` and add `quantumStyle` and `pendingQuantumStyle` state variables to `AddHabitSheet.js`.
- Render a new style-selection row in the `quantum` type panel and wire selection presses to `setPendingQuantumStyle`.
- Persist the selected style into the habit payload as `quantum.style` and restore it when initializing, applying, or resetting the sheet.
- Ensure default/reset/init code paths set `quantumStyle` to `QUANTUM_STYLE_OPTIONS[0].key` (`defaut`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695528a72074832685cc91a056173f0d)