### PR TITLE
Animate quantum water fill and preserve progress on edit

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -118,6 +118,11 @@ const QUANTUM_MODES = [
   { key: 'count', label: 'Count' },
 ];
 
+const QUANTUM_ANIMATIONS = [
+  { key: 'defaut', label: 'defaut' },
+  { key: 'water', label: 'water' },
+];
+
 const createTagKey = (label, existingKeys) => {
   const sanitized = label
     .toLowerCase()
@@ -449,6 +454,7 @@ export default function AddHabitSheet({
   const [selectedTag, setSelectedTag] = useState('none');
   const [selectedType, setSelectedType] = useState(DEFAULT_TYPE_OPTIONS[0].key);
   const [quantumMode, setQuantumMode] = useState(QUANTUM_MODES[0].key);
+  const [quantumAnimation, setQuantumAnimation] = useState(QUANTUM_ANIMATIONS[0].key);
   const [quantumTimerMinutes, setQuantumTimerMinutes] = useState('0');
   const [quantumTimerSeconds, setQuantumTimerSeconds] = useState('0');
   const [quantumCountValue, setQuantumCountValue] = useState('1');
@@ -474,6 +480,7 @@ export default function AddHabitSheet({
   const [pendingTag, setPendingTag] = useState(selectedTag);
   const [pendingType, setPendingType] = useState(selectedType);
   const [pendingQuantumMode, setPendingQuantumMode] = useState(quantumMode);
+  const [pendingQuantumAnimation, setPendingQuantumAnimation] = useState(quantumAnimation);
   const [pendingQuantumTimerMinutes, setPendingQuantumTimerMinutes] = useState(quantumTimerMinutes);
   const [pendingQuantumTimerSeconds, setPendingQuantumTimerSeconds] = useState(quantumTimerSeconds);
   const [pendingQuantumCountValue, setPendingQuantumCountValue] = useState(quantumCountValue);
@@ -603,6 +610,7 @@ export default function AddHabitSheet({
       } else if (panel === 'type') {
         setPendingType(selectedType);
         setPendingQuantumMode(quantumMode);
+        setPendingQuantumAnimation(quantumAnimation);
         setPendingQuantumTimerMinutes(quantumTimerMinutes);
         setPendingQuantumTimerSeconds(quantumTimerSeconds);
         setPendingQuantumCountValue(quantumCountValue);
@@ -617,6 +625,7 @@ export default function AddHabitSheet({
       hasSpecifiedTime,
       subtasks,
       quantumMode,
+      quantumAnimation,
       quantumTimerMinutes,
       quantumTimerSeconds,
       quantumCountValue,
@@ -727,6 +736,7 @@ export default function AddHabitSheet({
     setSelectedType(pendingType);
     if (pendingType === 'quantum') {
       setQuantumMode(pendingQuantumMode ?? QUANTUM_MODES[0].key);
+      setQuantumAnimation(pendingQuantumAnimation ?? QUANTUM_ANIMATIONS[0].key);
       setQuantumTimerMinutes(pendingQuantumTimerMinutes);
       setQuantumTimerSeconds(pendingQuantumTimerSeconds);
       setQuantumCountValue(pendingQuantumCountValue);
@@ -736,6 +746,7 @@ export default function AddHabitSheet({
   }, [
     closePanel,
     pendingQuantumMode,
+    pendingQuantumAnimation,
     pendingQuantumTimerMinutes,
     pendingQuantumTimerSeconds,
     pendingQuantumCountUnit,
@@ -844,6 +855,8 @@ export default function AddHabitSheet({
     const resolvedTagKey = initialHabit.tag ?? 'none';
     const resolvedTypeKey = initialHabit.type ?? DEFAULT_TYPE_OPTIONS[0].key;
     const resolvedQuantumMode = initialHabit.quantum?.mode ?? QUANTUM_MODES[0].key;
+    const resolvedQuantumAnimation =
+      initialHabit.quantum?.animation ?? QUANTUM_ANIMATIONS[0].key;
     const resolvedQuantumTimer = initialHabit.quantum?.timer ?? {};
     const resolvedQuantumCount = initialHabit.quantum?.count ?? {};
     const resolvedQuantumTimerMinutes = `${resolvedQuantumTimer.minutes ?? '0'}`;
@@ -874,6 +887,8 @@ export default function AddHabitSheet({
     setPendingType(resolvedTypeKey);
     setQuantumMode(resolvedQuantumMode);
     setPendingQuantumMode(resolvedQuantumMode);
+    setQuantumAnimation(resolvedQuantumAnimation);
+    setPendingQuantumAnimation(resolvedQuantumAnimation);
     setQuantumTimerMinutes(resolvedQuantumTimerMinutes);
     setQuantumTimerSeconds(resolvedQuantumTimerSeconds);
     setQuantumCountValue(resolvedQuantumCountValue);
@@ -979,6 +994,8 @@ export default function AddHabitSheet({
           setPendingType(DEFAULT_TYPE_OPTIONS[0].key);
           setQuantumMode(QUANTUM_MODES[0].key);
           setPendingQuantumMode(QUANTUM_MODES[0].key);
+          setQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
+          setPendingQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
           setQuantumTimerMinutes('0');
           setQuantumTimerSeconds('0');
           setQuantumCountValue('1');
@@ -1065,6 +1082,7 @@ export default function AddHabitSheet({
       typeLabel: selectedTypeOption.label,
       quantum: {
         mode: quantumMode,
+        animation: quantumAnimation,
         timer: {
           minutes: Number.parseInt(quantumTimerMinutes, 10) || 0,
           seconds: Number.parseInt(quantumTimerSeconds, 10) || 0,
@@ -1102,6 +1120,7 @@ export default function AddHabitSheet({
     selectedWeekdays,
     selectedType,
     quantumMode,
+    quantumAnimation,
     quantumTimerMinutes,
     quantumTimerSeconds,
     quantumCountValue,
@@ -1498,10 +1517,12 @@ export default function AddHabitSheet({
               {selectedType === 'quantum' ? (
                 <QuantumPanel
                   mode={quantumMode}
+                  animation={quantumAnimation}
                   timerMinutes={quantumTimerMinutes}
                   timerSeconds={quantumTimerSeconds}
                   countValue={quantumCountValue}
                   countUnit={quantumCountUnit}
+                  onChangeAnimation={setQuantumAnimation}
                   onChangeTimerMinutes={setQuantumTimerMinutes}
                   onChangeTimerSeconds={setQuantumTimerSeconds}
                   onChangeCountValue={setQuantumCountValue}
@@ -1658,10 +1679,12 @@ export default function AddHabitSheet({
                     </View>
                     <QuantumPanel
                       mode={pendingQuantumMode}
+                      animation={pendingQuantumAnimation}
                       timerMinutes={pendingQuantumTimerMinutes}
                       timerSeconds={pendingQuantumTimerSeconds}
                       countValue={pendingQuantumCountValue}
                       countUnit={pendingQuantumCountUnit}
+                      onChangeAnimation={setPendingQuantumAnimation}
                       onChangeTimerMinutes={setPendingQuantumTimerMinutes}
                       onChangeTimerSeconds={setPendingQuantumTimerSeconds}
                       onChangeCountValue={setPendingQuantumCountValue}
@@ -1866,10 +1889,12 @@ function normalizeNumericText(value, { max, fallback = '' } = {}) {
 
 function QuantumPanel({
   mode,
+  animation,
   timerMinutes,
   timerSeconds,
   countValue,
   countUnit,
+  onChangeAnimation,
   onChangeTimerMinutes,
   onChangeTimerSeconds,
   onChangeCountValue,
@@ -1942,6 +1967,35 @@ function QuantumPanel({
             </View>
           </View>
         )}
+        <View style={styles.quantumAnimationSection}>
+          <Text style={styles.quantumFieldLabel}>Animation</Text>
+          <View style={styles.quantumAnimationRow}>
+            {QUANTUM_ANIMATIONS.map((option) => {
+              const isSelected = animation === option.key;
+              return (
+                <Pressable
+                  key={option.key}
+                  style={[
+                    styles.quantumModeButton,
+                    isSelected && styles.quantumModeButtonSelected,
+                  ]}
+                  onPress={() => onChangeAnimation(option.key)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                >
+                  <Text
+                    style={[
+                      styles.quantumModeButtonText,
+                      isSelected && styles.quantumModeButtonTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
       </View>
       <Text style={styles.subtasksPanelHint}>
         {isTimer
@@ -2965,6 +3019,13 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   quantumCountRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  quantumAnimationSection: {
+    gap: 8,
+  },
+  quantumAnimationRow: {
     flexDirection: 'row',
     gap: 12,
   },


### PR DESCRIPTION
### Motivation
- Provide a more lively, animated water-fill visual for `quantum`-type habit cards so the water appears to move.
- Ensure quantum progress (timer/count) is not lost when editing a habit unless the quantum `mode` changes.

### Description
- Add helpers `clamp01` and `getQuantumProgressPercent` to compute a 0..1 progress ratio for quantum tasks and drive the fill height.
- Implement an animated wave using `Animated`, `Easing`, `Animated.loop` and a `waterWaveAnim` value, and render an `Animated.View` inside the existing `LinearGradient` fill with interpolated `translateX`/`translateY` transforms.
- Preserve quantum progress on edits by merging `quantum` when updating a task and only resetting `doneSeconds`/`doneCount` if the quantum `mode` changes.
- Add an animation picker (`QUANTUM_ANIMATIONS`) and state (`quantumAnimation` / `pendingQuantumAnimation`) in `AddHabitSheet`, wire it into `QuantumPanel`, and include `quantum.animation` in the created/updated payload.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554718e09c83269c0b22c996f430ad)