### PR TITLE
Increase visible motion for quantum water animation and add secondary wave

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,6 +4,7 @@ import {
   AppState,
   BackHandler,
   Dimensions,
+  Easing,
   Platform,
   Image,
   Modal,
@@ -472,6 +473,37 @@ const getQuantumProgressLabel = (task) => {
     return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
   }
   return null;
+};
+
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+
+const getQuantumProgressPercent = (task) => {
+  if (!task || task.type !== 'quantum' || !task.quantum) {
+    return 0;
+  }
+  const mode = task.quantum.mode;
+  if (mode === 'timer') {
+    const minutes = task.quantum.timer?.minutes ?? 0;
+    const seconds = task.quantum.timer?.seconds ?? 0;
+    const totalSeconds = minutes * 60 + seconds;
+    if (!totalSeconds) {
+      return 0;
+    }
+    const doneSeconds =
+      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    return clamp01(doneSeconds / totalSeconds);
+  }
+
+  if (mode === 'count') {
+    const limitValue = task.quantum.count?.value ?? 0;
+    if (!limitValue) {
+      return 0;
+    }
+    const doneCount = typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
+    return clamp01(doneCount / limitValue);
+  }
+
+  return 0;
 };
 
 const getTaskCompletionStatus = (task, date) => {
@@ -1742,6 +1774,17 @@ function ScheduleApp() {
           }
           const nextDate = normalizedDate ? new Date(normalizedDate) : new Date(task.date);
           nextDate.setHours(0, 0, 0, 0);
+          const nextQuantum = habit?.quantum ?? task.quantum;
+          let mergedQuantum = nextQuantum;
+          if (nextQuantum && task.quantum) {
+            const sameMode = nextQuantum.mode === task.quantum.mode;
+            mergedQuantum = {
+              ...task.quantum,
+              ...nextQuantum,
+              doneSeconds: sameMode ? task.quantum.doneSeconds ?? 0 : 0,
+              doneCount: sameMode ? task.quantum.doneCount ?? 0 : 0,
+            };
+          }
           return {
             ...task,
             title: nextTitle,
@@ -1756,7 +1799,7 @@ function ScheduleApp() {
             tagLabel: habit?.tagLabel,
             type: habit?.type,
             typeLabel: habit?.typeLabel,
-            quantum: habit?.quantum,
+            quantum: mergedQuantum,
             date: nextDate,
             dateKey: getDateKey(nextDate),
           };
@@ -2556,6 +2599,7 @@ function SwipeableTaskCard({
   onEdit,
 }) {
   const translateX = useRef(new Animated.Value(0)).current;
+  const waterWaveAnim = useRef(new Animated.Value(0)).current;
   const actionWidth = 168;
   const [isOpen, setIsOpen] = useState(false);
   const currentOffsetRef = useRef(0);
@@ -2649,6 +2693,47 @@ function SwipeableTaskCard({
   }, [completedSubtasks, task, totalSubtasks]);
 
   const isQuantum = task.type === 'quantum';
+  const isWaterAnimation = task.quantum?.animation === 'water';
+  const waterPercent = useMemo(() => getQuantumProgressPercent(task), [task]);
+  const waveTranslateX = waterWaveAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-80, 80],
+  });
+  const waveTranslateY = waterWaveAnim.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: [2, -10, 2],
+  });
+  const waveTranslateXAlt = waterWaveAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [60, -60],
+  });
+  const waveTranslateYAlt = waterWaveAnim.interpolate({
+    inputRange: [0, 0.5, 1],
+    outputRange: [-2, 8, -2],
+  });
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation) {
+      waterWaveAnim.stopAnimation();
+      waterWaveAnim.setValue(0);
+      return undefined;
+    }
+
+    const animationLoop = Animated.loop(
+      Animated.timing(waterWaveAnim, {
+        toValue: 1,
+        duration: 2800,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    );
+
+    animationLoop.start();
+    return () => {
+      animationLoop.stop();
+      waterWaveAnim.setValue(0);
+    };
+  }, [isQuantum, isWaterAnimation, waterWaveAnim]);
   const toggleAction = isQuantum ? onAdjustQuantum : onToggleCompletion;
   const isQuantumComplete = isQuantum && getQuantumProgressLabel(task) && task.completed;
 
@@ -2685,6 +2770,36 @@ function SwipeableTaskCard({
           },
         ]}
       >
+        {isQuantum && isWaterAnimation && (
+          <View pointerEvents="none" style={styles.waterFillContainer}>
+            <LinearGradient
+              colors={['rgba(107, 190, 255, 0.65)', 'rgba(64, 148, 255, 0.85)']}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={[styles.waterFill, { height: `${Math.round(waterPercent * 100)}%` }]}
+            >
+              <Animated.View
+                style={[
+                  styles.waterWave,
+                  {
+                    transform: [{ translateX: waveTranslateX }, { translateY: waveTranslateY }],
+                  },
+                ]}
+              />
+              <Animated.View
+                style={[
+                  styles.waterWaveSecondary,
+                  {
+                    transform: [
+                      { translateX: waveTranslateXAlt },
+                      { translateY: waveTranslateYAlt },
+                    ],
+                  },
+                ]}
+              />
+            </LinearGradient>
+          </View>
+        )}
         <Pressable style={styles.taskCardContent} onPress={handlePress}>
           <View style={styles.taskInfo}>
             {task.customImage ? (
@@ -3186,6 +3301,36 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: 16,
     borderWidth: 1,
+    overflow: 'hidden',
+  },
+  waterFillContainer: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 18,
+    overflow: 'hidden',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  },
+  waterFill: {
+    width: '100%',
+    position: 'relative',
+  },
+  waterWave: {
+    position: 'absolute',
+    top: -16,
+    left: -80,
+    right: -80,
+    height: 32,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255, 255, 255, 0.4)',
+  },
+  waterWaveSecondary: {
+    position: 'absolute',
+    top: -10,
+    left: -70,
+    right: -70,
+    height: 24,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255, 255, 255, 0.25)',
   },
   swipeableWrapper: {
     marginBottom: 14,

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -118,6 +118,11 @@ const QUANTUM_MODES = [
   { key: 'count', label: 'Count' },
 ];
 
+const QUANTUM_ANIMATIONS = [
+  { key: 'defaut', label: 'defaut' },
+  { key: 'water', label: 'water' },
+];
+
 const createTagKey = (label, existingKeys) => {
   const sanitized = label
     .toLowerCase()
@@ -449,6 +454,7 @@ export default function AddHabitSheet({
   const [selectedTag, setSelectedTag] = useState('none');
   const [selectedType, setSelectedType] = useState(DEFAULT_TYPE_OPTIONS[0].key);
   const [quantumMode, setQuantumMode] = useState(QUANTUM_MODES[0].key);
+  const [quantumAnimation, setQuantumAnimation] = useState(QUANTUM_ANIMATIONS[0].key);
   const [quantumTimerMinutes, setQuantumTimerMinutes] = useState('0');
   const [quantumTimerSeconds, setQuantumTimerSeconds] = useState('0');
   const [quantumCountValue, setQuantumCountValue] = useState('1');
@@ -474,6 +480,7 @@ export default function AddHabitSheet({
   const [pendingTag, setPendingTag] = useState(selectedTag);
   const [pendingType, setPendingType] = useState(selectedType);
   const [pendingQuantumMode, setPendingQuantumMode] = useState(quantumMode);
+  const [pendingQuantumAnimation, setPendingQuantumAnimation] = useState(quantumAnimation);
   const [pendingQuantumTimerMinutes, setPendingQuantumTimerMinutes] = useState(quantumTimerMinutes);
   const [pendingQuantumTimerSeconds, setPendingQuantumTimerSeconds] = useState(quantumTimerSeconds);
   const [pendingQuantumCountValue, setPendingQuantumCountValue] = useState(quantumCountValue);
@@ -603,6 +610,7 @@ export default function AddHabitSheet({
       } else if (panel === 'type') {
         setPendingType(selectedType);
         setPendingQuantumMode(quantumMode);
+        setPendingQuantumAnimation(quantumAnimation);
         setPendingQuantumTimerMinutes(quantumTimerMinutes);
         setPendingQuantumTimerSeconds(quantumTimerSeconds);
         setPendingQuantumCountValue(quantumCountValue);
@@ -617,6 +625,7 @@ export default function AddHabitSheet({
       hasSpecifiedTime,
       subtasks,
       quantumMode,
+      quantumAnimation,
       quantumTimerMinutes,
       quantumTimerSeconds,
       quantumCountValue,
@@ -727,6 +736,7 @@ export default function AddHabitSheet({
     setSelectedType(pendingType);
     if (pendingType === 'quantum') {
       setQuantumMode(pendingQuantumMode ?? QUANTUM_MODES[0].key);
+      setQuantumAnimation(pendingQuantumAnimation ?? QUANTUM_ANIMATIONS[0].key);
       setQuantumTimerMinutes(pendingQuantumTimerMinutes);
       setQuantumTimerSeconds(pendingQuantumTimerSeconds);
       setQuantumCountValue(pendingQuantumCountValue);
@@ -736,6 +746,7 @@ export default function AddHabitSheet({
   }, [
     closePanel,
     pendingQuantumMode,
+    pendingQuantumAnimation,
     pendingQuantumTimerMinutes,
     pendingQuantumTimerSeconds,
     pendingQuantumCountUnit,
@@ -844,6 +855,8 @@ export default function AddHabitSheet({
     const resolvedTagKey = initialHabit.tag ?? 'none';
     const resolvedTypeKey = initialHabit.type ?? DEFAULT_TYPE_OPTIONS[0].key;
     const resolvedQuantumMode = initialHabit.quantum?.mode ?? QUANTUM_MODES[0].key;
+    const resolvedQuantumAnimation =
+      initialHabit.quantum?.animation ?? QUANTUM_ANIMATIONS[0].key;
     const resolvedQuantumTimer = initialHabit.quantum?.timer ?? {};
     const resolvedQuantumCount = initialHabit.quantum?.count ?? {};
     const resolvedQuantumTimerMinutes = `${resolvedQuantumTimer.minutes ?? '0'}`;
@@ -874,6 +887,8 @@ export default function AddHabitSheet({
     setPendingType(resolvedTypeKey);
     setQuantumMode(resolvedQuantumMode);
     setPendingQuantumMode(resolvedQuantumMode);
+    setQuantumAnimation(resolvedQuantumAnimation);
+    setPendingQuantumAnimation(resolvedQuantumAnimation);
     setQuantumTimerMinutes(resolvedQuantumTimerMinutes);
     setQuantumTimerSeconds(resolvedQuantumTimerSeconds);
     setQuantumCountValue(resolvedQuantumCountValue);
@@ -979,6 +994,8 @@ export default function AddHabitSheet({
           setPendingType(DEFAULT_TYPE_OPTIONS[0].key);
           setQuantumMode(QUANTUM_MODES[0].key);
           setPendingQuantumMode(QUANTUM_MODES[0].key);
+          setQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
+          setPendingQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
           setQuantumTimerMinutes('0');
           setQuantumTimerSeconds('0');
           setQuantumCountValue('1');
@@ -1065,6 +1082,7 @@ export default function AddHabitSheet({
       typeLabel: selectedTypeOption.label,
       quantum: {
         mode: quantumMode,
+        animation: quantumAnimation,
         timer: {
           minutes: Number.parseInt(quantumTimerMinutes, 10) || 0,
           seconds: Number.parseInt(quantumTimerSeconds, 10) || 0,
@@ -1102,6 +1120,7 @@ export default function AddHabitSheet({
     selectedWeekdays,
     selectedType,
     quantumMode,
+    quantumAnimation,
     quantumTimerMinutes,
     quantumTimerSeconds,
     quantumCountValue,
@@ -1498,10 +1517,12 @@ export default function AddHabitSheet({
               {selectedType === 'quantum' ? (
                 <QuantumPanel
                   mode={quantumMode}
+                  animation={quantumAnimation}
                   timerMinutes={quantumTimerMinutes}
                   timerSeconds={quantumTimerSeconds}
                   countValue={quantumCountValue}
                   countUnit={quantumCountUnit}
+                  onChangeAnimation={setQuantumAnimation}
                   onChangeTimerMinutes={setQuantumTimerMinutes}
                   onChangeTimerSeconds={setQuantumTimerSeconds}
                   onChangeCountValue={setQuantumCountValue}
@@ -1658,10 +1679,12 @@ export default function AddHabitSheet({
                     </View>
                     <QuantumPanel
                       mode={pendingQuantumMode}
+                      animation={pendingQuantumAnimation}
                       timerMinutes={pendingQuantumTimerMinutes}
                       timerSeconds={pendingQuantumTimerSeconds}
                       countValue={pendingQuantumCountValue}
                       countUnit={pendingQuantumCountUnit}
+                      onChangeAnimation={setPendingQuantumAnimation}
                       onChangeTimerMinutes={setPendingQuantumTimerMinutes}
                       onChangeTimerSeconds={setPendingQuantumTimerSeconds}
                       onChangeCountValue={setPendingQuantumCountValue}
@@ -1866,10 +1889,12 @@ function normalizeNumericText(value, { max, fallback = '' } = {}) {
 
 function QuantumPanel({
   mode,
+  animation,
   timerMinutes,
   timerSeconds,
   countValue,
   countUnit,
+  onChangeAnimation,
   onChangeTimerMinutes,
   onChangeTimerSeconds,
   onChangeCountValue,
@@ -1942,6 +1967,35 @@ function QuantumPanel({
             </View>
           </View>
         )}
+        <View style={styles.quantumAnimationSection}>
+          <Text style={styles.quantumFieldLabel}>Animation</Text>
+          <View style={styles.quantumAnimationRow}>
+            {QUANTUM_ANIMATIONS.map((option) => {
+              const isSelected = animation === option.key;
+              return (
+                <Pressable
+                  key={option.key}
+                  style={[
+                    styles.quantumModeButton,
+                    isSelected && styles.quantumModeButtonSelected,
+                  ]}
+                  onPress={() => onChangeAnimation(option.key)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                >
+                  <Text
+                    style={[
+                      styles.quantumModeButtonText,
+                      isSelected && styles.quantumModeButtonTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
       </View>
       <Text style={styles.subtasksPanelHint}>
         {isTimer
@@ -2965,6 +3019,13 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   quantumCountRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  quantumAnimationSection: {
+    gap: 8,
+  },
+  quantumAnimationRow: {
     flexDirection: 'row',
     gap: 12,
   },


### PR DESCRIPTION
### Motivation
- Make quantum-type habit card water fill animate with more noticeable, liquid-like motion.  
- Expose a selectable animation option so the `water` animation can be chosen per-quantum habit.  
- Compute and drive the fill height from quantum progress so the visual matches the task state.  
- Improve visual realism by layering waves and tuning sizes, opacity, and travel ranges.  

### Description
- Speed up and change the wave loop to `duration: 2800` with `Easing.linear` for continuous motion.  
- Increase horizontal travel and add a secondary wave with alternate `translateX`/`translateY` interpolations and adjusted sizes/opacities.  
- Add helpers `clamp01` and `getQuantumProgressPercent` and render a `LinearGradient` fill whose height is driven by the computed quantum progress.  
- Add `QUANTUM_ANIMATIONS`, state (`quantumAnimation` / `pendingQuantumAnimation`), wire the picker into `QuantumPanel`, and include `quantum.animation` in created/updated payloads.  

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554718e09c83269c0b22c996f430ad)