### PR TITLE
Procedural SVG water waves with impact physics and quantum animation option

### DIFF
--- a/App.js
+++ b/App.js
@@ -21,7 +21,7 @@ import {
   ImageBackground,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import Svg, { Circle } from 'react-native-svg';
+import Svg, { Circle, Path } from 'react-native-svg';
 import { SafeAreaProvider, SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as ScreenOrientation from 'expo-screen-orientation';
@@ -104,6 +104,7 @@ const StickyMonthHeader = ({ date, customImages }) => {
 };
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 
 const habitImage = require('./assets/add-habit.png');
 const reflectionImage = require('./assets/add-reflection.png');
@@ -472,6 +473,80 @@ const getQuantumProgressLabel = (task) => {
     return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
   }
   return null;
+};
+
+const clamp01 = (value) => Math.min(1, Math.max(0, value));
+
+const getQuantumProgressPercent = (task) => {
+  if (!task || task.type !== 'quantum' || !task.quantum) {
+    return 0;
+  }
+  const mode = task.quantum.mode;
+  if (mode === 'timer') {
+    const minutes = task.quantum.timer?.minutes ?? 0;
+    const seconds = task.quantum.timer?.seconds ?? 0;
+    const totalSeconds = minutes * 60 + seconds;
+    if (!totalSeconds) {
+      return 0;
+    }
+    const doneSeconds =
+      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    return clamp01(doneSeconds / totalSeconds);
+  }
+
+  if (mode === 'count') {
+    const limitValue = task.quantum.count?.value ?? 0;
+    if (!limitValue) {
+      return 0;
+    }
+    const doneCount = typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
+    return clamp01(doneCount / limitValue);
+  }
+
+  return 0;
+};
+
+const mixChannel = (from, to, ratio) => Math.round(from + (to - from) * ratio);
+
+const interpolateHexColor = (from, to, ratio) => {
+  const normalize = (hex) => hex.replace('#', '');
+  const fromValue = parseInt(normalize(from), 16);
+  const toValue = parseInt(normalize(to), 16);
+  const fromRgb = {
+    r: (fromValue >> 16) & 255,
+    g: (fromValue >> 8) & 255,
+    b: fromValue & 255,
+  };
+  const toRgb = {
+    r: (toValue >> 16) & 255,
+    g: (toValue >> 8) & 255,
+    b: toValue & 255,
+  };
+  const mixed = {
+    r: mixChannel(fromRgb.r, toRgb.r, ratio),
+    g: mixChannel(fromRgb.g, toRgb.g, ratio),
+    b: mixChannel(fromRgb.b, toRgb.b, ratio),
+  };
+  return `#${[mixed.r, mixed.g, mixed.b].map((value) => value.toString(16).padStart(2, '0')).join('')}`;
+};
+
+const buildWavePath = ({ width, height, amplitude, phase }) => {
+  if (!width || !height) {
+    return '';
+  }
+  const points = 24;
+  const step = width / points;
+  const center = height * 0.5;
+  let path = `M 0 ${center}`;
+  for (let i = 0; i <= points; i += 1) {
+    const x = step * i;
+    const theta = (i / points) * Math.PI * 2 + phase;
+    const y = center + Math.sin(theta) * amplitude;
+    path += ` L ${x.toFixed(2)} ${y.toFixed(2)}`;
+  }
+  path += ` L ${width} ${height}`;
+  path += ` L 0 ${height} Z`;
+  return path;
 };
 
 const getTaskCompletionStatus = (task, date) => {
@@ -1249,6 +1324,7 @@ function ScheduleApp() {
               quantum: {
                 ...task.quantum,
                 doneSeconds: nextSeconds,
+                wavePulse: Date.now(),
               },
             };
           }
@@ -1283,6 +1359,7 @@ function ScheduleApp() {
             quantum: {
               ...task.quantum,
               doneCount: nextCount,
+              wavePulse: Date.now(),
             },
           };
         })
@@ -1742,6 +1819,17 @@ function ScheduleApp() {
           }
           const nextDate = normalizedDate ? new Date(normalizedDate) : new Date(task.date);
           nextDate.setHours(0, 0, 0, 0);
+          const nextQuantum = habit?.quantum ?? task.quantum;
+          let mergedQuantum = nextQuantum;
+          if (nextQuantum && task.quantum) {
+            const sameMode = nextQuantum.mode === task.quantum.mode;
+            mergedQuantum = {
+              ...task.quantum,
+              ...nextQuantum,
+              doneSeconds: sameMode ? task.quantum.doneSeconds ?? 0 : 0,
+              doneCount: sameMode ? task.quantum.doneCount ?? 0 : 0,
+            };
+          }
           return {
             ...task,
             title: nextTitle,
@@ -1756,7 +1844,7 @@ function ScheduleApp() {
             tagLabel: habit?.tagLabel,
             type: habit?.type,
             typeLabel: habit?.typeLabel,
-            quantum: habit?.quantum,
+            quantum: mergedQuantum,
             date: nextDate,
             dateKey: getDateKey(nextDate),
           };
@@ -2556,8 +2644,16 @@ function SwipeableTaskCard({
   onEdit,
 }) {
   const translateX = useRef(new Animated.Value(0)).current;
+  const waveIntensityAnim = useRef(new Animated.Value(1)).current;
   const actionWidth = 168;
   const [isOpen, setIsOpen] = useState(false);
+  const [cardSize, setCardSize] = useState({ width: 0, height: 0 });
+  const [wavePathFront, setWavePathFront] = useState('');
+  const [wavePathBack, setWavePathBack] = useState('');
+  const [waveColor, setWaveColor] = useState('#e9f5ff');
+  const waterLevelAnim = useRef(new Animated.Value(0)).current;
+  const wavePhaseRef = useRef(0);
+  const waveIntensityRef = useRef(1);
   const currentOffsetRef = useRef(0);
 
   useEffect(() => {
@@ -2649,6 +2745,117 @@ function SwipeableTaskCard({
   }, [completedSubtasks, task, totalSubtasks]);
 
   const isQuantum = task.type === 'quantum';
+  const isWaterAnimation = task.quantum?.animation === 'water';
+  const waterPercent = useMemo(() => getQuantumProgressPercent(task), [task]);
+  const waveHeight = 34;
+  const updateWavePaths = useCallback(() => {
+    if (!cardSize.width) {
+      return;
+    }
+    const intensityValue = waveIntensityRef.current;
+    const phaseValue = wavePhaseRef.current;
+    const frontAmplitude = 6 + intensityValue * 2.5;
+    const backAmplitude = 4 + intensityValue * 1.6;
+    const frontPath = buildWavePath({
+      width: cardSize.width,
+      height: waveHeight,
+      amplitude: frontAmplitude,
+      phase: phaseValue,
+    });
+    const backPath = buildWavePath({
+      width: cardSize.width,
+      height: waveHeight,
+      amplitude: backAmplitude,
+      phase: phaseValue + Math.PI / 2,
+    });
+    setWavePathFront(frontPath);
+    setWavePathBack(backPath);
+  }, [cardSize.width, waveHeight]);
+  const waterFillHeight = useMemo(() => {
+    if (!cardSize.height) {
+      return 0;
+    }
+    return waterLevelAnim.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, cardSize.height],
+    });
+  }, [cardSize.height, waterLevelAnim]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation) {
+      return undefined;
+    }
+    let animationFrame = null;
+    let lastTime = Date.now();
+    const tick = () => {
+      const now = Date.now();
+      const delta = now - lastTime;
+      lastTime = now;
+      const nextPhase = wavePhaseRef.current + (delta / 1000) * Math.PI * 1.6;
+      wavePhaseRef.current = nextPhase % (Math.PI * 2);
+      updateWavePaths();
+      animationFrame = requestAnimationFrame(tick);
+    };
+    animationFrame = requestAnimationFrame(tick);
+    return () => {
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [isQuantum, isWaterAnimation, updateWavePaths]);
+
+  useEffect(() => {
+    const intensityId = waveIntensityAnim.addListener(({ value }) => {
+      waveIntensityRef.current = value;
+      const normalized = clamp01((value - 1) / 4);
+      setWaveColor(interpolateHexColor('#e9f5ff', '#c3e6ff', normalized));
+      updateWavePaths();
+    });
+    return () => {
+      waveIntensityAnim.removeListener(intensityId);
+    };
+  }, [updateWavePaths, waveIntensityAnim]);
+
+  useEffect(() => {
+    updateWavePaths();
+  }, [cardSize.width, updateWavePaths]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation || !cardSize.height) {
+      return;
+    }
+    Animated.spring(waterLevelAnim, {
+      toValue: waterPercent,
+      damping: 10,
+      stiffness: 140,
+      mass: 0.9,
+      useNativeDriver: false,
+    }).start();
+  }, [cardSize.height, isQuantum, isWaterAnimation, waterLevelAnim, waterPercent]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation || !task.quantum?.wavePulse) {
+      return;
+    }
+    waveIntensityAnim.stopAnimation();
+    waveIntensityAnim.setValue(1);
+    Animated.sequence([
+      Animated.spring(waveIntensityAnim, {
+        toValue: 4.8,
+        damping: 6,
+        stiffness: 180,
+        mass: 0.6,
+        useNativeDriver: false,
+      }),
+      Animated.spring(waveIntensityAnim, {
+        toValue: 1,
+        damping: 8,
+        stiffness: 120,
+        mass: 0.8,
+        useNativeDriver: false,
+      }),
+    ]).start();
+  }, [isQuantum, isWaterAnimation, task.quantum?.wavePulse, waveIntensityAnim]);
   const toggleAction = isQuantum ? onAdjustQuantum : onToggleCompletion;
   const isQuantumComplete = isQuantum && getQuantumProgressLabel(task) && task.completed;
 
@@ -2684,7 +2891,30 @@ function SwipeableTaskCard({
             transform: [{ translateX }],
           },
         ]}
+        onLayout={(event) => {
+          const { width, height } = event.nativeEvent.layout;
+          setCardSize({ width, height });
+        }}
       >
+        {isQuantum && isWaterAnimation && (
+          <View pointerEvents="none" style={styles.waterFillContainer}>
+            <AnimatedLinearGradient
+              colors={['rgba(107, 190, 255, 0.6)', 'rgba(64, 148, 255, 0.9)']}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={[styles.waterFill, { height: waterFillHeight }]}
+            >
+              <Svg width={cardSize.width} height={waveHeight} style={styles.waterWaveSvg}>
+                {wavePathBack ? (
+                  <Path d={wavePathBack} fill={waveColor} opacity={0.55} />
+                ) : null}
+                {wavePathFront ? (
+                  <Path d={wavePathFront} fill="#f4fbff" opacity={0.8} />
+                ) : null}
+              </Svg>
+            </AnimatedLinearGradient>
+          </View>
+        )}
         <Pressable style={styles.taskCardContent} onPress={handlePress}>
           <View style={styles.taskInfo}>
             {task.customImage ? (
@@ -3186,6 +3416,24 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: 16,
     borderWidth: 1,
+    overflow: 'hidden',
+  },
+  waterFillContainer: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 18,
+    overflow: 'hidden',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  },
+  waterFill: {
+    width: '100%',
+    position: 'relative',
+  },
+  waterWaveSvg: {
+    position: 'absolute',
+    top: -18,
+    left: 0,
+    right: 0,
   },
   swipeableWrapper: {
     marginBottom: 14,

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -118,6 +118,11 @@ const QUANTUM_MODES = [
   { key: 'count', label: 'Count' },
 ];
 
+const QUANTUM_ANIMATIONS = [
+  { key: 'defaut', label: 'defaut' },
+  { key: 'water', label: 'water' },
+];
+
 const createTagKey = (label, existingKeys) => {
   const sanitized = label
     .toLowerCase()
@@ -449,6 +454,7 @@ export default function AddHabitSheet({
   const [selectedTag, setSelectedTag] = useState('none');
   const [selectedType, setSelectedType] = useState(DEFAULT_TYPE_OPTIONS[0].key);
   const [quantumMode, setQuantumMode] = useState(QUANTUM_MODES[0].key);
+  const [quantumAnimation, setQuantumAnimation] = useState(QUANTUM_ANIMATIONS[0].key);
   const [quantumTimerMinutes, setQuantumTimerMinutes] = useState('0');
   const [quantumTimerSeconds, setQuantumTimerSeconds] = useState('0');
   const [quantumCountValue, setQuantumCountValue] = useState('1');
@@ -474,6 +480,7 @@ export default function AddHabitSheet({
   const [pendingTag, setPendingTag] = useState(selectedTag);
   const [pendingType, setPendingType] = useState(selectedType);
   const [pendingQuantumMode, setPendingQuantumMode] = useState(quantumMode);
+  const [pendingQuantumAnimation, setPendingQuantumAnimation] = useState(quantumAnimation);
   const [pendingQuantumTimerMinutes, setPendingQuantumTimerMinutes] = useState(quantumTimerMinutes);
   const [pendingQuantumTimerSeconds, setPendingQuantumTimerSeconds] = useState(quantumTimerSeconds);
   const [pendingQuantumCountValue, setPendingQuantumCountValue] = useState(quantumCountValue);
@@ -603,6 +610,7 @@ export default function AddHabitSheet({
       } else if (panel === 'type') {
         setPendingType(selectedType);
         setPendingQuantumMode(quantumMode);
+        setPendingQuantumAnimation(quantumAnimation);
         setPendingQuantumTimerMinutes(quantumTimerMinutes);
         setPendingQuantumTimerSeconds(quantumTimerSeconds);
         setPendingQuantumCountValue(quantumCountValue);
@@ -617,6 +625,7 @@ export default function AddHabitSheet({
       hasSpecifiedTime,
       subtasks,
       quantumMode,
+      quantumAnimation,
       quantumTimerMinutes,
       quantumTimerSeconds,
       quantumCountValue,
@@ -727,6 +736,7 @@ export default function AddHabitSheet({
     setSelectedType(pendingType);
     if (pendingType === 'quantum') {
       setQuantumMode(pendingQuantumMode ?? QUANTUM_MODES[0].key);
+      setQuantumAnimation(pendingQuantumAnimation ?? QUANTUM_ANIMATIONS[0].key);
       setQuantumTimerMinutes(pendingQuantumTimerMinutes);
       setQuantumTimerSeconds(pendingQuantumTimerSeconds);
       setQuantumCountValue(pendingQuantumCountValue);
@@ -736,6 +746,7 @@ export default function AddHabitSheet({
   }, [
     closePanel,
     pendingQuantumMode,
+    pendingQuantumAnimation,
     pendingQuantumTimerMinutes,
     pendingQuantumTimerSeconds,
     pendingQuantumCountUnit,
@@ -844,6 +855,8 @@ export default function AddHabitSheet({
     const resolvedTagKey = initialHabit.tag ?? 'none';
     const resolvedTypeKey = initialHabit.type ?? DEFAULT_TYPE_OPTIONS[0].key;
     const resolvedQuantumMode = initialHabit.quantum?.mode ?? QUANTUM_MODES[0].key;
+    const resolvedQuantumAnimation =
+      initialHabit.quantum?.animation ?? QUANTUM_ANIMATIONS[0].key;
     const resolvedQuantumTimer = initialHabit.quantum?.timer ?? {};
     const resolvedQuantumCount = initialHabit.quantum?.count ?? {};
     const resolvedQuantumTimerMinutes = `${resolvedQuantumTimer.minutes ?? '0'}`;
@@ -874,6 +887,8 @@ export default function AddHabitSheet({
     setPendingType(resolvedTypeKey);
     setQuantumMode(resolvedQuantumMode);
     setPendingQuantumMode(resolvedQuantumMode);
+    setQuantumAnimation(resolvedQuantumAnimation);
+    setPendingQuantumAnimation(resolvedQuantumAnimation);
     setQuantumTimerMinutes(resolvedQuantumTimerMinutes);
     setQuantumTimerSeconds(resolvedQuantumTimerSeconds);
     setQuantumCountValue(resolvedQuantumCountValue);
@@ -979,6 +994,8 @@ export default function AddHabitSheet({
           setPendingType(DEFAULT_TYPE_OPTIONS[0].key);
           setQuantumMode(QUANTUM_MODES[0].key);
           setPendingQuantumMode(QUANTUM_MODES[0].key);
+          setQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
+          setPendingQuantumAnimation(QUANTUM_ANIMATIONS[0].key);
           setQuantumTimerMinutes('0');
           setQuantumTimerSeconds('0');
           setQuantumCountValue('1');
@@ -1065,6 +1082,7 @@ export default function AddHabitSheet({
       typeLabel: selectedTypeOption.label,
       quantum: {
         mode: quantumMode,
+        animation: quantumAnimation,
         timer: {
           minutes: Number.parseInt(quantumTimerMinutes, 10) || 0,
           seconds: Number.parseInt(quantumTimerSeconds, 10) || 0,
@@ -1102,6 +1120,7 @@ export default function AddHabitSheet({
     selectedWeekdays,
     selectedType,
     quantumMode,
+    quantumAnimation,
     quantumTimerMinutes,
     quantumTimerSeconds,
     quantumCountValue,
@@ -1498,10 +1517,12 @@ export default function AddHabitSheet({
               {selectedType === 'quantum' ? (
                 <QuantumPanel
                   mode={quantumMode}
+                  animation={quantumAnimation}
                   timerMinutes={quantumTimerMinutes}
                   timerSeconds={quantumTimerSeconds}
                   countValue={quantumCountValue}
                   countUnit={quantumCountUnit}
+                  onChangeAnimation={setQuantumAnimation}
                   onChangeTimerMinutes={setQuantumTimerMinutes}
                   onChangeTimerSeconds={setQuantumTimerSeconds}
                   onChangeCountValue={setQuantumCountValue}
@@ -1658,10 +1679,12 @@ export default function AddHabitSheet({
                     </View>
                     <QuantumPanel
                       mode={pendingQuantumMode}
+                      animation={pendingQuantumAnimation}
                       timerMinutes={pendingQuantumTimerMinutes}
                       timerSeconds={pendingQuantumTimerSeconds}
                       countValue={pendingQuantumCountValue}
                       countUnit={pendingQuantumCountUnit}
+                      onChangeAnimation={setPendingQuantumAnimation}
                       onChangeTimerMinutes={setPendingQuantumTimerMinutes}
                       onChangeTimerSeconds={setPendingQuantumTimerSeconds}
                       onChangeCountValue={setPendingQuantumCountValue}
@@ -1866,10 +1889,12 @@ function normalizeNumericText(value, { max, fallback = '' } = {}) {
 
 function QuantumPanel({
   mode,
+  animation,
   timerMinutes,
   timerSeconds,
   countValue,
   countUnit,
+  onChangeAnimation,
   onChangeTimerMinutes,
   onChangeTimerSeconds,
   onChangeCountValue,
@@ -1942,6 +1967,35 @@ function QuantumPanel({
             </View>
           </View>
         )}
+        <View style={styles.quantumAnimationSection}>
+          <Text style={styles.quantumFieldLabel}>Animation</Text>
+          <View style={styles.quantumAnimationRow}>
+            {QUANTUM_ANIMATIONS.map((option) => {
+              const isSelected = animation === option.key;
+              return (
+                <Pressable
+                  key={option.key}
+                  style={[
+                    styles.quantumModeButton,
+                    isSelected && styles.quantumModeButtonSelected,
+                  ]}
+                  onPress={() => onChangeAnimation(option.key)}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                >
+                  <Text
+                    style={[
+                      styles.quantumModeButtonText,
+                      isSelected && styles.quantumModeButtonTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
       </View>
       <Text style={styles.subtasksPanelHint}>
         {isTimer
@@ -2965,6 +3019,13 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   quantumCountRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  quantumAnimationSection: {
+    gap: 8,
+  },
+  quantumAnimationRow: {
     flexDirection: 'row',
     gap: 12,
   },


### PR DESCRIPTION
### Motivation
- Replace simple rounded-View water visuals with fluid, procedural waves to give water a natural, weighty motion and reactive impact behavior.
- Drive wave motion and amplitude from frame-tied phase updates instead of an `Animated.loop` for smoother, frame-accurate movement.
- Provide a selectable quantum animation so quantum-type tasks can use the new water effect and react visually when progress changes.
- Preserve user quantum progress when switching habit configuration modes by merging quantum state on update.

### Description
- Implemented procedural SVG wave rendering with `buildWavePath` and added dual `Path` layers inside an animated `LinearGradient` to create depth and parallax; replaced oval Views with `Svg` + `Path` components and added styles (`waterFillContainer`, `waterFill`, `waterWaveSvg`).
- Replaced the `Animated.loop`/`Easing` phase animation with a `requestAnimationFrame` driven phase stored in `wavePhaseRef`, and removed the unused `Easing` import and `wavePhaseAnim` listener.
- Added impact/agitation physics via `waveIntensityAnim` and `wavePulse` timestamps (set when quantum values are adjusted), triggering `Animated.spring` sequences to temporarily boost amplitude; water level now animates using `waterLevelAnim` via `Animated.spring` to produce bounce.
- Exposed a new animation option for quantum tasks by adding `QUANTUM_ANIMATIONS`, `quantumAnimation` and `pendingQuantumAnimation` in `AddHabitSheet`, wired the picker into `QuantumPanel` with `onChangeAnimation`, and merged quantum payloads when keeping the same mode to preserve `doneSeconds`/`doneCount`.

### Testing
- No automated tests were executed for these changes.
- Visual/manual verification on device or emulator is recommended because the changes rely on `react-native-svg` and animated frame timing for correct appearance and performance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69554718e09c83269c0b22c996f430ad)