### PR TITLE
Fix disappearing recurring tasks by normalizing repeat fields and defaults

### DIFF
--- a/utils/taskUtils.js
+++ b/utils/taskUtils.js
@@ -16,10 +16,6 @@ const getTaskCompletionStatus = (task, date) => {
     return Boolean(task.completedDates[dateKey]);
   }
 
-  if (!task.repeat && task.dateKey) {
-    return task.dateKey === dateKey ? Boolean(task.completed) : false;
-  }
-
   return false;
 };
 


### PR DESCRIPTION
### Motivation
- Recurring tasks could be filtered out when stored repeat data used different field names or missing values like `frequency`, `option`, or `enabled`.
- Millisecond-based date math and timezone noise caused unstable repeat calculations across days.
- Legacy boolean `completed` fields produced inconsistent completion state between storage and UI.
- Rapid state updates risked overwriting persisted state and month layout heuristics caused scrolling flicker.

### Description
- Rewrote `shouldTaskAppearOnDate` to normalize inputs and accept `repeat.frequency` or legacy `repeat.option`, parse `interval`, respect `endDate`, and use calendar-safe comparisons via `differenceInCalendarDays`/`differenceInCalendarMonths` and `startOfDay`.
- Ensured new tasks receive a sane repeat default by normalizing `repeat` in `handleCreateHabit` to ` { enabled: true, frequency: 'daily', interval: 1 }` when missing and defaulting `type` to `normal`.
- Normalized stored tasks on hydrate with `normalizeStoredTasks` to migrate legacy `completed` booleans into `completedDates` and removed reliance on top-level `completed` across updates.
- Replaced fixed month height heuristics by using `calculateWeeksInMonth` and consolidated saves into a single debounced effect that batches `saveTasks`, `saveUserSettings`, and `saveHistory` after 500ms.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d18ebc088326a83c4e1200c07f18)