### PR TITLE
Handle repeat defaults in date utils

### DIFF
--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -123,7 +123,18 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
     return false;
   }
 
-  const frequency = repeat.frequency || repeat.option || 'daily';
+  const frequency = repeat.frequency || repeat.option;
+  const supportedFrequencies = new Set([
+    'daily',
+    'interval',
+    'weekly',
+    'monthly',
+    'weekend',
+    'weekdays',
+  ]);
+  if (!frequency || !supportedFrequencies.has(frequency)) {
+    return false;
+  }
   const interval = Number.parseInt(repeat.interval, 10) || 1;
 
   const endDate = normalizeDateValue(repeat.endDate);


### PR DESCRIPTION
### Motivation

- Fix tasks disappearing after their start date when `repeat` is missing or invalid by treating such tasks as non-repeating beyond the start date.
- Normalize how the repeat `frequency` is chosen to avoid inconsistent fallbacks.
- Ensure that an undefined `repeat.enabled` does not block a task from appearing on its start date.
- Keep date comparisons robust to time-of-day noise by using `startOfDay` with date-fns comparison helpers.

### Description

- Updated `shouldTaskAppearOnDate` to select `frequency` via `repeat.frequency || repeat.option`.
- Added a `supportedFrequencies` guard so missing or invalid `frequency` values are treated as non-repeating.
- Retained explicit blocking only when `repeat.enabled === false`, allowing `undefined` to be permissive.
- Continued using `startOfDay` combined with `differenceInCalendarDays`/`differenceInCalendarMonths` for accurate date comparisons.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d6dead0c832691436f14dfb9a561)