### PR TITLE
Handle fallback repeats for quantum tasks

### DIFF
--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -118,8 +118,25 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
     return false;
   }
 
-  const repeat = task.repeat;
-  if (!repeat || repeat.option === 'off' || repeat.enabled === false) {
+  const isQuantumTask = task.type === 'quantum';
+  let repeat = task.repeat;
+  if (!repeat) {
+    repeat = {
+      frequency: 'daily',
+      option: 'daily',
+      interval: 1,
+      enabled: true,
+    };
+  }
+  if (isQuantumTask && repeat.option === 'off') {
+    repeat = {
+      ...repeat,
+      option: 'daily',
+      frequency: repeat.frequency || 'daily',
+      enabled: true,
+    };
+  }
+  if (repeat.option === 'off' || repeat.enabled === false) {
     return false;
   }
 


### PR DESCRIPTION
### Motivation
- `shouldTaskAppearOnDate` could hide tasks when `repeat` was absent or explicitly `off`, causing quantum tasks to not display.  
- Quantum tasks should be allowed to appear even if their `repeat` data is missing or set to `off`.  
- Provide a clear fallback repeat behavior (e.g., daily) so display logic is not blocked by missing repeat metadata.  
- Keep honoring explicit disabled repeats for non-quantum tasks.

### Description
- Detect quantum tasks by checking `task.type === 'quantum'` and expose this via an `isQuantumTask` flag inside `shouldTaskAppearOnDate`.  
- When `task.repeat` is falsy, inject a fallback repeat object with `frequency: 'daily'`, `option: 'daily'`, `interval: 1`, and `enabled: true`.  
- For quantum tasks where `repeat.option === 'off'`, override `option` to `'daily'` and set `enabled: true` while preserving other repeat fields.  
- Preserve the existing repeat evaluation logic and the early-return when `repeat.option === 'off'` or `repeat.enabled === false` for non-overridden cases and continue using `frequency`/`interval` as before.

### Testing
- No automated tests were run for this change.  
- No unit tests or CI checks were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d6e3ff6c8326b7e81a43f084b4ad)