### PR TITLE
Harden repeat interval and frequency handling in utils/dateUtils.js

### DIFF
--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -83,6 +83,14 @@ const normalizeRepeatCollection = (value) => {
   return [];
 };
 
+const normalizeRepeatInterval = (value, fallback = 1) => {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return parsed;
+};
+
 const isSameDay = (dateA, dateB) => {
   if (!dateA || !dateB) {
     return false;
@@ -123,8 +131,9 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
     return false;
   }
 
-  const frequency = repeat.frequency || repeat.option || 'daily';
-  const interval = Number.parseInt(repeat.interval, 10) || 1;
+  const rawFrequency = repeat.frequency || repeat.option || 'daily';
+  const frequency = rawFrequency === 'interval' ? 'daily' : rawFrequency;
+  const interval = normalizeRepeatInterval(repeat.interval);
 
   const endDate = normalizeDateValue(repeat.endDate);
   if (endDate && isBefore(endDate, targetDay)) {


### PR DESCRIPTION
### Motivation
- Ensure repeat `interval` values are validated and never treated as zero or negative by enforcing `>= 1`.
- Provide a safe fallback when `repeat.interval` is missing or invalid to avoid unexpected behavior.
- Make sure an absent `repeat.enabled` property does not implicitly block repeated tasks by only treating explicit `false` as blocking.
- Treat `repeat.option === 'interval'` as equivalent to a daily frequency for consistent handling.

### Description
- Added `normalizeRepeatInterval` which parses `repeat.interval` and returns a fallback of `1` when the value is `NaN` or less than `1`.
- Normalized raw frequency with `const frequency = rawFrequency === 'interval' ? 'daily' : rawFrequency;` and switched `shouldTaskAppearOnDate` to use the normalized `interval`.
- Left the `repeat.enabled` check explicit so only `repeat.enabled === false` prevents repeats, while an undefined `enabled` remains permissive.
- Updated `shouldTaskAppearOnDate` to rely on the normalized frequency and interval values for daily/interval schedule calculations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d6e630488326826c5874bb99ce47)