### PR TITLE
Normalize completion dates and remove legacy `task.completed` fallbacks

### DIFF
--- a/utils/taskUtils.js
+++ b/utils/taskUtils.js
@@ -53,11 +53,7 @@ const getQuantumProgressLabel = (task) => {
       return null;
     }
     const doneSeconds =
-      typeof task.quantum.doneSeconds === 'number'
-        ? task.quantum.doneSeconds
-        : task.completed
-        ? limitSeconds
-        : 0;
+      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
     return `${formatDuration(doneSeconds)}/${formatDuration(limitSeconds)}`;
   }
   if (mode === 'count') {
@@ -67,11 +63,7 @@ const getQuantumProgressLabel = (task) => {
     }
     const unit = task.quantum.count?.unit?.trim() ?? '';
     const doneValue =
-      typeof task.quantum.doneCount === 'number'
-        ? task.quantum.doneCount
-        : task.completed
-        ? limitValue
-        : 0;
+      typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
     return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
   }
   return null;


### PR DESCRIPTION
### Motivation
- Ensure stored task and subtask completion maps are normalized when hydrating from storage to avoid malformed data causing runtime errors.
- Make toggling completion deterministic by always resolving a concrete `dateKey` before updating `completedDates`.
- Remove legacy fallbacks that relied on `task.completed` for quantum progress display to prefer explicit per-date progress values.

### Description
- Add `normalizeCompletedDates` and filter out falsy entries in `normalizeStoredTasks` to coerce `completedDates` into an object and set `dateKey` from the task base date.
- Update hydration to normalize subtask `completedDates` and strip legacy `completed` flags from stored tasks/subtasks when returning normalized tasks.
- Resolve a concrete date key in `handleToggleTaskCompletion` and `handleToggleSubtask` (falling back to the task `dateKey` or derived `date`) and always update the `completedDates` map for that key.
- Change quantum progress label logic in `utils/taskUtils.js` to stop using `task.completed` as a fallback and only use explicit `doneSeconds`/`doneCount` values.

### Testing
- No automated tests were run as part of this change.
- Changes were committed and files modified: `App.js` and `utils/taskUtils.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d6ecf4948326a100b117b7d9fbf5)