### PR TITLE
Fix hook dependencies and remove unused styles

### DIFF
--- a/App.js
+++ b/App.js
@@ -616,10 +616,10 @@ function ScheduleApp() {
     });
 
     return layouts;
-  }, []);
+  }, [BASE_HEIGHT]);
   const monthLayouts = useMemo(() => {
     return buildMonthLayouts(calendarMonths);
-  }, [buildMonthLayouts, calendarMonths, width]);
+  }, [buildMonthLayouts, calendarMonths]);
   const monthLayoutsRef = useRef(monthLayouts);
   useEffect(() => {
     monthLayoutsRef.current = monthLayouts;
@@ -648,7 +648,7 @@ function ScheduleApp() {
     const now = new Date();
     now.setHours(0, 0, 0, 0);
     return now;
-  }, []);
+  }, [normalizeStoredTasks]);
   const todayKey = useMemo(() => getDateKey(today), [today]);
   const selectedDateKey = useMemo(() => getDateKey(selectedDate), [selectedDate]);
   const isSelectedToday = selectedDateKey === todayKey;
@@ -2421,7 +2421,7 @@ function SwipeableTaskCard({
     });
     setWavePathFront(frontPath);
     setWavePathBack(backPath);
-  }, [cardSize.width, waveHeight, waveIntensityAnim, wavePhaseAnim]);
+  }, [cardSize.width, waveHeight]);
   const waterFillHeight = useMemo(() => {
     if (!cardSize.height) {
       return 0;
@@ -2773,12 +2773,8 @@ function QuantumAdjustModal({
   onSubtract,
   onClose,
 }) {
-  if (!visible || !task) {
-    return null;
-  }
-
-  const isTimer = task.quantum?.mode === 'timer';
-  const limitLabel = getQuantumProgressLabel(task);
+  const isTimer = task?.quantum?.mode === 'timer';
+  const limitLabel = task ? getQuantumProgressLabel(task) : null;
   const handleMinutesChange = useCallback(
     (value) => {
       onChangeMinutes(value.replace(/\D/g, '').slice(0, 2));
@@ -2800,6 +2796,10 @@ function QuantumAdjustModal({
   const disableActions = isTimer
     ? (Number.parseInt(minutesValue, 10) || 0) * 60 + (Number.parseInt(secondsValue, 10) || 0) <= 0
     : (Number.parseInt(countValue, 10) || 0) <= 0;
+
+  if (!visible || !task) {
+    return null;
+  }
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
@@ -3166,12 +3166,6 @@ const styles = StyleSheet.create({
     borderRadius: 23,
     resizeMode: 'cover',
   },
-  taskEmojiImage: {
-    width: 38,
-    height: 38,
-    borderRadius: 19,
-    resizeMode: 'cover',
-  },
   taskDetails: {
     marginLeft: 12,
     flex: 1,
@@ -3442,15 +3436,6 @@ const styles = StyleSheet.create({
     paddingBottom: 60,
     gap: 12,
   },
-  calendarMonthSection: {
-    marginBottom: 24,
-  },
-  calendarMonthSeparator: {
-    height: 12,
-    backgroundColor: '#000000',
-    borderRadius: 6,
-    marginBottom: 12,
-  },
   calendarMonthContainer: {
     marginBottom: 20,
     marginHorizontal: 0,
@@ -3695,11 +3680,6 @@ const styles = StyleSheet.create({
     textShadowOffset: { width: 1, height: 1 },
     textShadowRadius: 4,
   },
-  headerOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.15)',
-    borderRadius: 0,
-  },
   // --- ESTILOS DO RELATÓRIO ---
   reportOverlay: {
     flex: 1,
@@ -3927,10 +3907,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     justifyContent: 'center',
     paddingHorizontal: 16,
-  },
-  customizeCardOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.2)',
   },
   customizeCardText: {
     color: '#fff',

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -1133,10 +1133,6 @@ export default function AddHabitSheet({
     customImage,
     tagOptions,
     typeOptions,
-    pendingQuantumTimerMinutes,
-    pendingQuantumTimerSeconds,
-    pendingQuantumCountValue,
-    pendingQuantumCountUnit,
   ]);
 
   const panResponder = useMemo(
@@ -3408,14 +3404,6 @@ const styles = StyleSheet.create({
   repeatContent: {
     gap: 18,
   },
-  weekdayToggleRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    paddingHorizontal: 16,
-    paddingBottom: 12,
-    paddingTop: 10,
-    gap: 8,
-  },
   weekdayGrid: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -3472,24 +3460,6 @@ const styles = StyleSheet.create({
   },
   monthDayLabelActive: {
     color: '#1F2742',
-  },
-  weekdayToggle: {
-    flex: 1,
-    height: 44,
-    borderRadius: 16,
-    backgroundColor: '#E8EEFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  weekdayToggleActive: {
-    backgroundColor: '#1F2742',
-  },
-  weekdayToggleLabel: {
-    color: '#1F2742',
-    fontWeight: '600',
-  },
-  weekdayToggleLabelActive: {
-    color: '#FFFFFF',
   },
   timePanel: {
     backgroundColor: '#F5F7FF',


### PR DESCRIPTION
### Motivation
- Address ESLint complaints about incorrect React Hook dependency arrays and conditional hook calls to ensure stable hook behavior.
- Prevent hooks from being invoked conditionally inside `QuantumAdjustModal` to comply with the rules of hooks.
- Remove duplicate and unused style entries to eliminate `no-dupe-keys` and `react-native/no-unused-styles` warnings.
- Trim unnecessary dependencies from memoized callbacks to reduce unnecessary re-renders.

### Description
- Added `BASE_HEIGHT` to the dependency list of `buildMonthLayouts` and removed `width` from the `monthLayouts` `useMemo` dependencies by updating `monthLayouts` and related hooks to use the stable `buildMonthLayouts` result.
- Included `normalizeStoredTasks` where required to satisfy a missing dependency warning and adjusted the `useMemo`/`useEffect` dependency arrays accordingly.
- Removed `waveIntensityAnim` and `wavePhaseAnim` from the `updateWavePaths` callback dependencies since the callback uses refs for those values instead of the animated objects.
- Reworked `QuantumAdjustModal` to compute `isTimer` and `limitLabel` defensively and moved the early `return null` to after the dependent callbacks so hooks are not called conditionally, and removed duplicate/unused styles such as duplicate `taskEmojiImage` and several calendar/customize style entries; also removed unused weekday toggle styles and dropped `pendingQuantum*` values from a long dependency array in `components/AddHabitSheet.js`.

### Testing
- No automated tests were executed as part of this change.
- The patch was committed successfully and the repository shows the two modified files staged and committed.
- ESLint warnings that motivated this change were addressed in source edits, but the linter was not run as part of this rollout.
- Manual runtime verification was not performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956dd5dd45483268c478bee9f93fa7a)