### PR TITLE
Fix hook dependency warnings in App.js

### DIFF
--- a/App.js
+++ b/App.js
@@ -648,7 +648,7 @@ function ScheduleApp() {
     const now = new Date();
     now.setHours(0, 0, 0, 0);
     return now;
-  }, [normalizeStoredTasks]);
+  }, []);
   const todayKey = useMemo(() => getDateKey(today), [today]);
   const selectedDateKey = useMemo(() => getDateKey(selectedDate), [selectedDate]);
   const isSelectedToday = selectedDateKey === todayKey;
@@ -725,7 +725,7 @@ function ScheduleApp() {
 
   const handleOpenReport = useCallback((date) => {
     setReportDate(date);
-  }, [normalizeStoredTasks]);
+  }, []);
 
   const loadMoreCalendarMonths = useCallback(() => {
     setCalendarMonths((previous) => {
@@ -741,7 +741,7 @@ function ScheduleApp() {
       }
       return [...previous, { id: nextId, date: nextMonthDate }];
     });
-  }, [normalizeStoredTasks]);
+  }, []);
 
   const renderCalendarMonth = useCallback(
     ({ item }) => (
@@ -1078,7 +1078,7 @@ function ScheduleApp() {
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [normalizeStoredTasks]);
 
   useEffect(() => {
     if (!isHydrated) {


### PR DESCRIPTION
### Motivation
- Resolve ESLint `react-hooks/exhaustive-deps` warnings related to `normalizeStoredTasks` reported in `App.js`.
- Prevent unnecessary recomputations and re-creations of memoized values and callbacks caused by an irrelevant dependency.
- Ensure the hydration effect depends on `normalizeStoredTasks` so it uses the correct normalization function when loading stored tasks.

### Description
- Removed `normalizeStoredTasks` from the dependency array of the `useMemo` that builds `today` (`today` now uses `[]`).
- Removed `normalizeStoredTasks` from the dependency arrays of the `useCallback` hooks `handleOpenReport` and `loadMoreCalendarMonths` (they now use `[]`).
- Added `normalizeStoredTasks` to the dependency array of the hydration `useEffect` that calls `hydrateFromStorage` so the effect will re-run if the callback changes.
- Changes applied to `App.js` to address the hook dependency warnings and keep hook semantics correct.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e5bbe6ec8326ae7ac92564b77095)