### PR TITLE
Add profile task list toggle

### DIFF
--- a/App.js
+++ b/App.js
@@ -569,6 +569,8 @@ function ScheduleApp() {
   const [history, setHistory] = useState([]);
   const [customMonthImages, setCustomMonthImages] = useState({});
   const [isHydrated, setIsHydrated] = useState(false);
+  const [isProfileTasksOpen, setProfileTasksOpen] = useState(false);
+  const [profileTaskImageErrors, setProfileTaskImageErrors] = useState({});
   const saveTimeoutRef = useRef(null);
   const [calendarMonths, setCalendarMonths] = useState(() => {
     const today = new Date();
@@ -722,6 +724,19 @@ function ScheduleApp() {
         };
       });
   }, [reportDate, tasks]);
+
+  const profileTaskItems = useMemo(
+    () =>
+      tasks.map((task) => ({
+        ...task,
+        totalSubtasks: Array.isArray(task.subtasks) ? task.subtasks.length : 0,
+      })),
+    [tasks]
+  );
+
+  useEffect(() => {
+    setProfileTaskImageErrors({});
+  }, [tasks]);
 
   const handleOpenReport = useCallback((date) => {
     setReportDate(date);
@@ -1700,8 +1715,8 @@ function ScheduleApp() {
           style={[
             styles.content,
             dynamicStyles.content,
-            activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
-            activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0, alignItems: 'center', justifyContent: 'center' },
+          activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
+          activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
           ]}
           importantForAccessibility={isFabOpen ? 'no-hide-descendants' : 'auto'}
         >
@@ -1919,7 +1934,11 @@ function ScheduleApp() {
               />
             </View>
           ) : activeTab === 'profile' ? (
-             <View style={styles.profileContainer}>
+            <ScrollView
+              contentContainerStyle={styles.profileScrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.profileHeader}>
                 <View style={styles.avatarContainer}>
                   <Ionicons name="person" size={40} color="#3c2ba7" />
                 </View>
@@ -1934,10 +1953,87 @@ function ScheduleApp() {
                   onPress={() => setCustomizeCalendarOpen(true)}
                   activeOpacity={0.8}
                 >
-                   <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
-                   <Text style={styles.customizeButtonText}>Customize Calendar</Text>
+                  <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
+                  <Text style={styles.customizeButtonText}>Customize Calendar</Text>
                 </TouchableOpacity>
-             </View>
+              </View>
+
+              <View style={styles.profileTasksSection}>
+                <View style={styles.profileTasksHeader}>
+                  <Text style={styles.profileTasksTitle}>All tasks</Text>
+                  <TouchableOpacity
+                    style={styles.profileTasksToggle}
+                    onPress={() => setProfileTasksOpen((previous) => !previous)}
+                    accessibilityRole="button"
+                    accessibilityLabel={isProfileTasksOpen ? 'Hide all tasks' : 'View all tasks'}
+                  >
+                    <Ionicons
+                      name={isProfileTasksOpen ? 'chevron-up' : 'chevron-down'}
+                      size={16}
+                      color="#3c2ba7"
+                    />
+                    <Text style={styles.profileTasksToggleText}>
+                      {isProfileTasksOpen ? 'Hide' : 'View'}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+
+                {isProfileTasksOpen && (
+                  <>
+                    {profileTaskItems.length === 0 ? (
+                      <Text style={styles.profileTasksEmpty}>No tasks created yet.</Text>
+                    ) : (
+                      <View style={styles.profileTasksList}>
+                        {profileTaskItems.map((task) => {
+                          const baseColor = task.color || '#3c2ba7';
+                          const lightBg = lightenColor(baseColor, 0.85);
+
+                          return (
+                            <View
+                              key={task.id}
+                              style={[
+                                styles.reportTaskRow,
+                                {
+                                  backgroundColor: lightBg,
+                                  borderColor: lightenColor(baseColor, 0.6),
+                                  borderWidth: 1,
+                                },
+                              ]}
+                            >
+                              <View style={[styles.reportTaskIcon, { backgroundColor: '#fff' }]}>
+                                {task.customImage && !profileTaskImageErrors[task.id] ? (
+                                  <Image
+                                    source={{ uri: task.customImage }}
+                                    style={styles.reportTaskIconImage}
+                                    onError={() =>
+                                      setProfileTaskImageErrors((prev) => ({
+                                        ...prev,
+                                        [task.id]: true,
+                                      }))
+                                    }
+                                  />
+                                ) : (
+                                  <Text style={{ fontSize: 18 }}>{task.emoji || FALLBACK_EMOJI}</Text>
+                                )}
+                              </View>
+
+                              <View style={{ flex: 1 }}>
+                                <Text style={styles.reportTaskTitle}>{task.title}</Text>
+                                {task.totalSubtasks > 0 && (
+                                  <Text style={styles.profileTaskMeta}>
+                                    {task.totalSubtasks} subtasks
+                                  </Text>
+                                )}
+                              </View>
+                            </View>
+                          );
+                        })}
+                      </View>
+                    )}
+                  </>
+                )}
+              </View>
+            </ScrollView>
           ) : (
             <View style={styles.placeholderContainer}>
               <View style={styles.placeholderIconWrapper}>
@@ -3825,11 +3921,15 @@ const styles = StyleSheet.create({
   },
 
   // --- STYLES FOR PROFILE & CUSTOMIZE CALENDAR ---
-  profileContainer: {
-    flex: 1,
+  profileScrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 120,
+  },
+  profileHeader: {
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
+    marginBottom: 32,
   },
   avatarContainer: {
     width: 80,
@@ -3870,6 +3970,47 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  profileTasksSection: {
+    width: '100%',
+  },
+  profileTasksHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  profileTasksTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1a1a2e',
+  },
+  profileTasksToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#f0efff',
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    borderRadius: 20,
+  },
+  profileTasksToggleText: {
+    marginLeft: 6,
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#3c2ba7',
+  },
+  profileTasksList: {
+    gap: 12,
+  },
+  profileTasksEmpty: {
+    color: '#6f7a86',
+    textAlign: 'center',
+    paddingVertical: 12,
+  },
+  profileTaskMeta: {
+    fontSize: 12,
+    color: '#6f7a86',
+    marginTop: 4,
   },
   
   // Customize Modal Styles


### PR DESCRIPTION
### Motivation

- Provide a Profile view option to inspect all created tasks in a simplified list, matching the quick-overview pattern used in the calendar day/habits view.
- Surface basic task metadata (title, emoji/image, subtask counts) so users can quickly scan existing tasks without opening each card.
- Keep the Profile screen scrollable to accommodate the full task list and avoid clipping on smaller devices.

### Description

- Implemented a toggleable `All tasks` section in the Profile tab by adding `isProfileTasksOpen` and `profileTaskImageErrors` state and a `profileTaskItems` `useMemo` derived from `tasks` in `App.js`.
- Replaced the centered profile layout with a scrollable layout (`profileScrollContent`, `profileHeader`) and added UI for the toggle and simplified task rows that reuse the existing `reportTaskRow`/`reportTaskIcon` styles.
- Added image error handling to fall back to the task `emoji` when `task.customImage` fails and show the subtasks count via a computed `totalSubtasks` field.
- Added new styles for the profile task section (`profileTasksSection`, `profileTasksHeader`, `profileTasksToggle`, `profileTasksList`, `profileTaskMeta`) and adjusted the profile layout condition to remove forced centering when `activeTab === 'profile'`.

### Testing

- No automated tests were executed for this change.
- The change was applied to `App.js` and committed (one file modified, UI/behavior changes limited to the Profile tab and related styles).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e89e5a70832692737e5c2637576a)