### PR TITLE
Open profile tasks in modal

### DIFF
--- a/App.js
+++ b/App.js
@@ -307,6 +307,72 @@ function CustomizeCalendarModal({ visible, onClose, customImages, onUpdateImage 
   );
 }
 
+function ProfileTasksModal({ visible, onClose, tasks, imageErrors, onImageError }) {
+  if (!visible) return null;
+
+  return (
+    <Modal animationType="slide" transparent={false} visible={visible} onRequestClose={onClose}>
+      <SafeAreaView style={styles.profileTasksModalContainer}>
+        <View style={styles.profileTasksModalHeader}>
+          <Text style={styles.profileTasksModalTitle}>All tasks</Text>
+          <Pressable onPress={onClose} hitSlop={12}>
+            <Ionicons name="close" size={28} color="#1a1a2e" />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.profileTasksModalContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {tasks.length === 0 ? (
+            <Text style={styles.profileTasksEmpty}>No tasks created yet.</Text>
+          ) : (
+            tasks.map((task) => {
+              const baseColor = task.color || '#3c2ba7';
+              const lightBg = lightenColor(baseColor, 0.85);
+
+              return (
+                <View
+                  key={task.id}
+                  style={[
+                    styles.reportTaskRow,
+                    {
+                      backgroundColor: lightBg,
+                      borderColor: lightenColor(baseColor, 0.6),
+                      borderWidth: 1,
+                    },
+                  ]}
+                >
+                  <View style={[styles.reportTaskIcon, { backgroundColor: '#fff' }]}>
+                    {task.customImage && !imageErrors[task.id] ? (
+                      <Image
+                        source={{ uri: task.customImage }}
+                        style={styles.reportTaskIconImage}
+                        onError={() => onImageError(task.id)}
+                      />
+                    ) : (
+                      <Text style={{ fontSize: 18 }}>{task.emoji || FALLBACK_EMOJI}</Text>
+                    )}
+                  </View>
+
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.reportTaskTitle}>{task.title}</Text>
+                    {task.totalSubtasks > 0 && (
+                      <Text style={styles.profileTaskMeta}>
+                        {task.totalSubtasks} subtasks
+                      </Text>
+                    )}
+                  </View>
+                </View>
+              );
+            })
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
 
 function DayReportModal({ visible, date, tasks, onClose, customImages }) {
   const { height } = useWindowDimensions();
@@ -569,6 +635,8 @@ function ScheduleApp() {
   const [history, setHistory] = useState([]);
   const [customMonthImages, setCustomMonthImages] = useState({});
   const [isHydrated, setIsHydrated] = useState(false);
+  const [isProfileTasksOpen, setProfileTasksOpen] = useState(false);
+  const [profileTaskImageErrors, setProfileTaskImageErrors] = useState({});
   const saveTimeoutRef = useRef(null);
   const [calendarMonths, setCalendarMonths] = useState(() => {
     const today = new Date();
@@ -722,6 +790,26 @@ function ScheduleApp() {
         };
       });
   }, [reportDate, tasks]);
+
+  const profileTaskItems = useMemo(
+    () =>
+      tasks.map((task) => ({
+        ...task,
+        totalSubtasks: Array.isArray(task.subtasks) ? task.subtasks.length : 0,
+      })),
+    [tasks]
+  );
+
+  useEffect(() => {
+    setProfileTaskImageErrors({});
+  }, [tasks]);
+
+  const handleProfileTaskImageError = useCallback((taskId) => {
+    setProfileTaskImageErrors((prev) => ({
+      ...prev,
+      [taskId]: true,
+    }));
+  }, []);
 
   const handleOpenReport = useCallback((date) => {
     setReportDate(date);
@@ -1700,8 +1788,8 @@ function ScheduleApp() {
           style={[
             styles.content,
             dynamicStyles.content,
-            activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
-            activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0, alignItems: 'center', justifyContent: 'center' },
+          activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
+          activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
           ]}
           importantForAccessibility={isFabOpen ? 'no-hide-descendants' : 'auto'}
         >
@@ -1919,7 +2007,11 @@ function ScheduleApp() {
               />
             </View>
           ) : activeTab === 'profile' ? (
-             <View style={styles.profileContainer}>
+            <ScrollView
+              contentContainerStyle={styles.profileScrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.profileHeader}>
                 <View style={styles.avatarContainer}>
                   <Ionicons name="person" size={40} color="#3c2ba7" />
                 </View>
@@ -1934,10 +2026,25 @@ function ScheduleApp() {
                   onPress={() => setCustomizeCalendarOpen(true)}
                   activeOpacity={0.8}
                 >
-                   <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
-                   <Text style={styles.customizeButtonText}>Customize Calendar</Text>
+                  <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
+                  <Text style={styles.customizeButtonText}>Customize Calendar</Text>
                 </TouchableOpacity>
-             </View>
+
+                <TouchableOpacity
+                  style={[styles.customizeButton, styles.profileActionButton]}
+                  onPress={() => setProfileTasksOpen(true)}
+                  activeOpacity={0.8}
+                >
+                  <Ionicons
+                    name="list-outline"
+                    size={20}
+                    color="#fff"
+                    style={{ marginRight: 8 }}
+                  />
+                  <Text style={styles.customizeButtonText}>View Tasks</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
           ) : (
             <View style={styles.placeholderContainer}>
               <View style={styles.placeholderIconWrapper}>
@@ -2270,6 +2377,13 @@ function ScheduleApp() {
         onClose={() => setCustomizeCalendarOpen(false)}
         customImages={customMonthImages}
         onUpdateImage={handleUpdateMonthImage}
+      />
+      <ProfileTasksModal
+        visible={isProfileTasksOpen}
+        onClose={() => setProfileTasksOpen(false)}
+        tasks={profileTaskItems}
+        imageErrors={profileTaskImageErrors}
+        onImageError={handleProfileTaskImageError}
       />
     </View>
   );
@@ -3825,11 +3939,15 @@ const styles = StyleSheet.create({
   },
 
   // --- STYLES FOR PROFILE & CUSTOMIZE CALENDAR ---
-  profileContainer: {
-    flex: 1,
+  profileScrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 120,
+  },
+  profileHeader: {
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
+    marginBottom: 32,
   },
   avatarContainer: {
     width: 80,
@@ -3870,6 +3988,42 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  profileActionButton: {
+    marginTop: 12,
+  },
+  profileTasksEmpty: {
+    color: '#6f7a86',
+    textAlign: 'center',
+    paddingVertical: 12,
+  },
+  profileTaskMeta: {
+    fontSize: 12,
+    color: '#6f7a86',
+    marginTop: 4,
+  },
+
+  profileTasksModalContainer: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  profileTasksModalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+  },
+  profileTasksModalTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1a1a2e',
+  },
+  profileTasksModalContent: {
+    padding: 20,
+    gap: 12,
   },
   
   // Customize Modal Styles


### PR DESCRIPTION
### Motivation
- Replace the inline "All tasks" list on the Profile screen with a dedicated view that uses the same UX pattern as `CustomizeCalendar` so the list opens in a separate window instead of expanding inline.
- Fix the profile action button placement and add an icon so the action matches other quick actions in the UI.
- Keep the same image fallback behavior used by the calendar customization for task images to avoid broken images.

### Description
- Added a new `ProfileTasksModal` component that renders the full task list inside a `Modal` and mirrors the calendar customization image + emoji fallback logic.
- Replaced the inline profile task section with a `View Tasks` action that opens the modal by setting `isProfileTasksOpen` to `true` and removed the inline expand/collapse UI.
- Introduced `profileTaskItems` (`useMemo`), `profileTaskImageErrors` state, and `handleProfileTaskImageError` to track image failures and reset on `tasks` change.
- Converted the profile content to a scrollable layout and added/updated related styles (`profileScrollContent`, `profileHeader`, `profileTasksModal*`, `profileActionButton`) to match the new modal flow.

### Testing
- No automated tests were executed for this change.
- The change was implemented and committed, but no CI/build/test run was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e89e5a70832692737e5c2637576a)