### PR TITLE
Add richer task metadata to Profile tasks modal

### DIFF
--- a/App.js
+++ b/App.js
@@ -124,6 +124,30 @@ const normalizeRepeatConfig = (repeatConfig) => {
   };
 };
 
+const formatRepeatLabel = (repeat) => {
+  if (!repeat?.enabled) {
+    return 'Once';
+  }
+
+  const interval = repeat.interval ?? 1;
+  const frequency = repeat.frequency ?? 'daily';
+  const labels = {
+    daily: 'Daily',
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+    yearly: 'Yearly',
+  };
+  const baseLabel = labels[frequency] ?? frequency;
+
+  if (interval === 1) {
+    return baseLabel;
+  }
+
+  const lower = baseLabel.toLowerCase();
+  const pluralSuffix = interval > 1 && !lower.endsWith('s') ? 's' : '';
+  return `Every ${interval} ${lower}${pluralSuffix}`;
+};
+
 const triggerImpact = (style) => {
   if (!HAPTICS_SUPPORTED) {
     return;
@@ -301,6 +325,89 @@ function CustomizeCalendarModal({ visible, onClose, customImages, onUpdateImage 
               </View>
             );
           })}
+        </ScrollView>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+function ProfileTasksModal({ visible, onClose, tasks, imageErrors, onImageError }) {
+  if (!visible) return null;
+
+  return (
+    <Modal animationType="slide" transparent={false} visible={visible} onRequestClose={onClose}>
+      <SafeAreaView style={styles.profileTasksModalContainer}>
+        <View style={styles.profileTasksModalHeader}>
+          <Text style={styles.profileTasksModalTitle}>All tasks</Text>
+          <Pressable onPress={onClose} hitSlop={12}>
+            <Ionicons name="close" size={28} color="#1a1a2e" />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.profileTasksModalContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {tasks.length === 0 ? (
+            <Text style={styles.profileTasksEmpty}>No tasks created yet.</Text>
+          ) : (
+            tasks.map((task) => {
+              const baseColor = task.color || '#3c2ba7';
+              const lightBg = lightenColor(baseColor, 0.85);
+              const primaryMeta = [
+                formatTaskTime(task.time),
+                formatRepeatLabel(task.repeat),
+              ]
+                .filter(Boolean)
+                .join(' • ');
+              const secondaryMeta = [
+                task.tagLabel ? `Tag: ${task.tagLabel}` : null,
+                task.typeLabel ? `Type: ${task.typeLabel}` : null,
+                task.date ? `Start ${format(task.date, 'd MMM')}` : null,
+              ]
+                .filter(Boolean)
+                .join(' • ');
+
+              return (
+                <View
+                  key={task.id}
+                  style={[
+                    styles.reportTaskRow,
+                    {
+                      backgroundColor: lightBg,
+                      borderColor: lightenColor(baseColor, 0.6),
+                      borderWidth: 1,
+                    },
+                  ]}
+                >
+                  <View style={[styles.reportTaskIcon, { backgroundColor: '#fff' }]}>
+                    {task.customImage && !imageErrors[task.id] ? (
+                      <Image
+                        source={{ uri: task.customImage }}
+                        style={styles.reportTaskIconImage}
+                        onError={() => onImageError(task.id)}
+                      />
+                    ) : (
+                      <Text style={{ fontSize: 18 }}>{task.emoji || FALLBACK_EMOJI}</Text>
+                    )}
+                  </View>
+
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.reportTaskTitle}>{task.title}</Text>
+                    <Text style={styles.profileTaskMeta}>{primaryMeta}</Text>
+                    {secondaryMeta.length > 0 && (
+                      <Text style={styles.profileTaskMeta}>{secondaryMeta}</Text>
+                    )}
+                    {task.totalSubtasks > 0 && (
+                      <Text style={styles.profileTaskMeta}>
+                        {task.totalSubtasks} subtasks
+                      </Text>
+                    )}
+                  </View>
+                </View>
+              );
+            })
+          )}
         </ScrollView>
       </SafeAreaView>
     </Modal>
@@ -569,6 +676,8 @@ function ScheduleApp() {
   const [history, setHistory] = useState([]);
   const [customMonthImages, setCustomMonthImages] = useState({});
   const [isHydrated, setIsHydrated] = useState(false);
+  const [isProfileTasksOpen, setProfileTasksOpen] = useState(false);
+  const [profileTaskImageErrors, setProfileTaskImageErrors] = useState({});
   const saveTimeoutRef = useRef(null);
   const [calendarMonths, setCalendarMonths] = useState(() => {
     const today = new Date();
@@ -722,6 +831,26 @@ function ScheduleApp() {
         };
       });
   }, [reportDate, tasks]);
+
+  const profileTaskItems = useMemo(
+    () =>
+      tasks.map((task) => ({
+        ...task,
+        totalSubtasks: Array.isArray(task.subtasks) ? task.subtasks.length : 0,
+      })),
+    [tasks]
+  );
+
+  useEffect(() => {
+    setProfileTaskImageErrors({});
+  }, [tasks]);
+
+  const handleProfileTaskImageError = useCallback((taskId) => {
+    setProfileTaskImageErrors((prev) => ({
+      ...prev,
+      [taskId]: true,
+    }));
+  }, []);
 
   const handleOpenReport = useCallback((date) => {
     setReportDate(date);
@@ -1700,8 +1829,8 @@ function ScheduleApp() {
           style={[
             styles.content,
             dynamicStyles.content,
-            activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
-            activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0, alignItems: 'center', justifyContent: 'center' },
+          activeTab === 'calendar' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
+          activeTab === 'profile' && { paddingHorizontal: 0, paddingTop: 0, paddingBottom: 0 },
           ]}
           importantForAccessibility={isFabOpen ? 'no-hide-descendants' : 'auto'}
         >
@@ -1919,7 +2048,11 @@ function ScheduleApp() {
               />
             </View>
           ) : activeTab === 'profile' ? (
-             <View style={styles.profileContainer}>
+            <ScrollView
+              contentContainerStyle={styles.profileScrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <View style={styles.profileHeader}>
                 <View style={styles.avatarContainer}>
                   <Ionicons name="person" size={40} color="#3c2ba7" />
                 </View>
@@ -1934,10 +2067,25 @@ function ScheduleApp() {
                   onPress={() => setCustomizeCalendarOpen(true)}
                   activeOpacity={0.8}
                 >
-                   <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
-                   <Text style={styles.customizeButtonText}>Customize Calendar</Text>
+                  <Ionicons name="images-outline" size={20} color="#fff" style={{ marginRight: 8 }} />
+                  <Text style={styles.customizeButtonText}>Customize Calendar</Text>
                 </TouchableOpacity>
-             </View>
+
+                <TouchableOpacity
+                  style={[styles.customizeButton, styles.profileActionButton]}
+                  onPress={() => setProfileTasksOpen(true)}
+                  activeOpacity={0.8}
+                >
+                  <Ionicons
+                    name="list-outline"
+                    size={20}
+                    color="#fff"
+                    style={{ marginRight: 8 }}
+                  />
+                  <Text style={styles.customizeButtonText}>View Tasks</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
           ) : (
             <View style={styles.placeholderContainer}>
               <View style={styles.placeholderIconWrapper}>
@@ -2270,6 +2418,13 @@ function ScheduleApp() {
         onClose={() => setCustomizeCalendarOpen(false)}
         customImages={customMonthImages}
         onUpdateImage={handleUpdateMonthImage}
+      />
+      <ProfileTasksModal
+        visible={isProfileTasksOpen}
+        onClose={() => setProfileTasksOpen(false)}
+        tasks={profileTaskItems}
+        imageErrors={profileTaskImageErrors}
+        onImageError={handleProfileTaskImageError}
       />
     </View>
   );
@@ -3825,11 +3980,15 @@ const styles = StyleSheet.create({
   },
 
   // --- STYLES FOR PROFILE & CUSTOMIZE CALENDAR ---
-  profileContainer: {
-    flex: 1,
+  profileScrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+    paddingTop: 32,
+    paddingBottom: 120,
+  },
+  profileHeader: {
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
+    marginBottom: 32,
   },
   avatarContainer: {
     width: 80,
@@ -3870,6 +4029,42 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  profileActionButton: {
+    marginTop: 12,
+  },
+  profileTasksEmpty: {
+    color: '#6f7a86',
+    textAlign: 'center',
+    paddingVertical: 12,
+  },
+  profileTaskMeta: {
+    fontSize: 12,
+    color: '#6f7a86',
+    marginTop: 4,
+  },
+
+  profileTasksModalContainer: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  profileTasksModalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+  },
+  profileTasksModalTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1a1a2e',
+  },
+  profileTasksModalContent: {
+    padding: 20,
+    gap: 12,
   },
   
   // Customize Modal Styles


### PR DESCRIPTION
### Motivation
- Improve card distinguishability in the Profile task list by surfacing more useful metadata per task (time, repeat cadence, tag, type, start date and subtask count). 
- Provide a concise human-readable repeat label instead of raw repeat config values for better at-a-glance scanning.
- Move the profile tasks into a modal with a dedicated action so the list is easier to scan and does not expand inline.

### Description
- Added `formatRepeatLabel` to format repeat configuration into readable strings like `Daily` or `Every 2 weeks`.
- Introduced `ProfileTasksModal` which renders task rows with `primaryMeta` (time + repeat) and `secondaryMeta` (tag, type, start date) while preserving the subtask count and image/emoji fallback logic. 
- Added state and helpers: `isProfileTasksOpen`, `profileTaskImageErrors`, `profileTaskItems`, and `handleProfileTaskImageError`, and wired a `View Tasks` button to open the modal via `setProfileTasksOpen(true)`.
- Updated profile layout to a scrollable layout and added styles including `profileTaskMeta`, `profileTasksModal*`, `profileScrollContent`, and `profileActionButton` to support the new UI.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e89e5a70832692737e5c2637576a)