### PR TITLE
Remove lock badge from swipe actions

### DIFF
--- a/App.js
+++ b/App.js
@@ -2601,12 +2601,6 @@ function SwipeableTaskCard({
   return (
     <View style={[styles.swipeableWrapper, { zIndex: isOpen ? 10 : 1 }]}>
       <View style={styles.swipeableActions}>
-        {task.profileLocked ? (
-          <View style={styles.swipeLockBadge}>
-            <Ionicons name="lock-closed" size={14} color="#3c2ba7" />
-            <Text style={styles.swipeLockText}>Locked</Text>
-          </View>
-        ) : null}
         <TouchableOpacity
           style={[styles.swipeActionButton, styles.swipeActionCopy]}
           onPress={() => handleAction(onCopy)}


### PR DESCRIPTION
### Motivation
- Make locked and unlocked task cards look identical when swiping so the UI matches the intended behavior.
- Keep the functional difference that locked cards cannot be deleted while removing the visual "Locked" label.
- This is a small presentation change inside the swipe actions area of task cards.

### Description
- Removed the conditional JSX that rendered the lock badge (`Ionicons` + `Text` "Locked") from `SwipeableTaskCard` in `App.js`.
- Kept the `disabled={task.profileLocked}` guard on the delete `TouchableOpacity` so delete remains disabled for locked tasks.
- Change is limited to `App.js` and only affects the swipe action layout and visibility of the lock label.

### Testing
- No automated tests were executed for this UI-only change.
- Manual verification is expected via the Expo Snack / device to confirm locked cards no longer show the "Locked" badge and delete remains disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b279c561c83269f177bd38075e086)