### PR TITLE
Dim delete swipe action for locked tasks

### DIFF
--- a/App.js
+++ b/App.js
@@ -2601,12 +2601,6 @@ function SwipeableTaskCard({
   return (
     <View style={[styles.swipeableWrapper, { zIndex: isOpen ? 10 : 1 }]}>
       <View style={styles.swipeableActions}>
-        {task.profileLocked ? (
-          <View style={styles.swipeLockBadge}>
-            <Ionicons name="lock-closed" size={14} color="#3c2ba7" />
-            <Text style={styles.swipeLockText}>Locked</Text>
-          </View>
-        ) : null}
         <TouchableOpacity
           style={[styles.swipeActionButton, styles.swipeActionCopy]}
           onPress={() => handleAction(onCopy)}
@@ -2620,6 +2614,7 @@ function SwipeableTaskCard({
           style={[
             styles.swipeActionButton,
             styles.swipeActionDelete,
+            task.profileLocked && styles.swipeActionButtonDisabled,
           ]}
           onPress={() => handleAction(onDelete)}
           accessibilityRole="button"
@@ -2631,6 +2626,7 @@ function SwipeableTaskCard({
             style={[
               styles.swipeActionText,
               styles.swipeActionTextDelete,
+              task.profileLocked && styles.swipeActionTextDisabled,
             ]}
           >
             Delete


### PR DESCRIPTION
### Motivation
- Make it visually clear that the delete swipe action is unavailable when a task is locked by dimming the control.  
- Preserve the functional protection that locked tasks cannot be deleted while improving the affordance.  
- Provide a visual replacement for the removed lock badge so users understand deletion is disabled.  

### Description
- Apply `styles.swipeActionButtonDisabled` to the delete swipe `TouchableOpacity` when `task.profileLocked` is true.  
- Apply `styles.swipeActionTextDisabled` to the delete label when `task.profileLocked` is true.  
- Keep the existing `disabled={task.profileLocked}` prop on the delete action and only modify styling in `App.js`.  

### Testing
- No automated tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b279c561c83269f177bd38075e086)