### PR TITLE
Profile: show lock icon on locked task cards and dim delete swipe action

### DIFF
--- a/App.js
+++ b/App.js
@@ -2601,12 +2601,6 @@ function SwipeableTaskCard({
   return (
     <View style={[styles.swipeableWrapper, { zIndex: isOpen ? 10 : 1 }]}>
       <View style={styles.swipeableActions}>
-        {task.profileLocked ? (
-          <View style={styles.swipeLockBadge}>
-            <Ionicons name="lock-closed" size={14} color="#3c2ba7" />
-            <Text style={styles.swipeLockText}>Locked</Text>
-          </View>
-        ) : null}
         <TouchableOpacity
           style={[styles.swipeActionButton, styles.swipeActionCopy]}
           onPress={() => handleAction(onCopy)}
@@ -2620,6 +2614,7 @@ function SwipeableTaskCard({
           style={[
             styles.swipeActionButton,
             styles.swipeActionDelete,
+            task.profileLocked && styles.swipeActionButtonDisabled,
           ]}
           onPress={() => handleAction(onDelete)}
           accessibilityRole="button"
@@ -2631,6 +2626,7 @@ function SwipeableTaskCard({
             style={[
               styles.swipeActionText,
               styles.swipeActionTextDelete,
+              task.profileLocked && styles.swipeActionTextDisabled,
             ]}
           >
             Delete
@@ -2876,9 +2872,19 @@ function ProfileSwipeTaskCard({
             )}
           </View>
           <View style={styles.profileTaskDetails}>
-            <Text style={styles.profileTaskTitle} numberOfLines={1}>
-              {task.title}
-            </Text>
+            <View style={styles.profileTaskTitleRow}>
+              <Text style={styles.profileTaskTitle} numberOfLines={1}>
+                {task.title}
+              </Text>
+              {task.profileLocked ? (
+                <Ionicons
+                  name="lock-closed"
+                  size={14}
+                  color="#9aa3b2"
+                  style={styles.profileTaskLockIcon}
+                />
+              ) : null}
+            </View>
             <View style={styles.profileTaskMetaRow}>
               <Text style={styles.profileTaskTime}>{formatTaskTime(task.time)}</Text>
               {tagLabel ? (
@@ -4771,10 +4777,18 @@ const styles = StyleSheet.create({
     flex: 1,
     marginLeft: 12,
   },
+  profileTaskTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   profileTaskTitle: {
     fontSize: 15,
     fontWeight: '600',
     color: '#1a1a2e',
+    flexShrink: 1,
+  },
+  profileTaskLockIcon: {
+    marginLeft: 6,
   },
   profileTaskMetaRow: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
- Make it visually clear in the profile task list when a task is locked by showing a subtle lock next to the task title.
- Keep the deletion protection for locked tasks and provide a clear affordance that deletion is disabled.
- Restrict the UI change to profile task cards so other card types are unaffected.

### Description
- Wrap the profile task title in a new `View` (`styles.profileTaskTitleRow`) and conditionally render an `Ionicons` `lock-closed` icon when `task.profileLocked` is true.
- Add `styles.profileTaskTitleRow`, `styles.profileTaskLockIcon`, and set `profileTaskTitle` to `flexShrink: 1` to avoid layout overflow.
- Apply disabled styling to the swipe delete action by adding `task.profileLocked && styles.swipeActionButtonDisabled` and `task.profileLocked && styles.swipeActionTextDisabled`, and remove the old swipe lock badge.
- Commit message: `Add lock icon to profile task titles`.

### Testing
- No automated tests were run for these UI-only changes.
- Changes were validated by building and inspecting the updated `App.js` source in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b279c561c83269f177bd38075e086)