### PR TITLE
Use shared TaskCard component for habit previews

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,7 +4,6 @@ import {
   AppState,
   BackHandler,
   Dimensions,
-  Easing,
   Platform,
   Image,
   Modal,
@@ -51,6 +50,7 @@ import {
   saveUserSettings,
 } from './storage';
 import AddHabitSheet from './components/AddHabitSheet';
+import TaskCard from './components/TaskCard';
 import { MONTH_NAMES, getMonthImageSource } from './constants/months';
 import { DEFAULT_USER_SETTINGS } from './constants/userSettings';
 import { LEFT_TABS, RIGHT_TABS, getNavigationBarThemeForTab } from './constants/navigation';
@@ -62,17 +62,15 @@ import {
   normalizeDateValue,
   shouldTaskAppearOnDate,
 } from './utils/dateUtils';
-import { clamp01, clampValue } from './utils/mathUtils';
+import { clampValue } from './utils/mathUtils';
 import {
   getQuantumProgressLabel,
-  getQuantumProgressPercent,
   getSubtaskCompletionStatus,
   getTaskCompletionStatus,
   getTaskTagDisplayLabel,
   normalizeTaskTagKey,
 } from './utils/taskUtils';
 import { formatTaskTime, toMinutes } from './utils/timeUtils';
-import { buildWavePath } from './utils/waveUtils';
 
 // --- COMPONENTE DA FAIXA DO TOPO ---
 const StickyMonthHeader = ({ date, customImages }) => {
@@ -2372,18 +2370,8 @@ function SwipeableTaskCard({
   onEdit,
 }) {
   const translateX = useRef(new Animated.Value(0)).current;
-  const wavePhaseAnim = useRef(new Animated.Value(0)).current;
-  const waveIntensityAnim = useRef(new Animated.Value(1)).current;
   const actionWidth = 168;
   const [isOpen, setIsOpen] = useState(false);
-  const [cardSize, setCardSize] = useState({ width: 0, height: 0 });
-  const [wavePathFront, setWavePathFront] = useState('');
-  const [wavePathBack, setWavePathBack] = useState('');
-  const [waveColor, setWaveColor] = useState('#e9f5ff');
-  const [hasImageError, setHasImageError] = useState(false);
-  const waterLevelAnim = useRef(new Animated.Value(0)).current;
-  const wavePhaseRef = useRef(0);
-  const waveIntensityRef = useRef(1);
   const currentOffsetRef = useRef(0);
 
   useEffect(() => {
@@ -2394,10 +2382,6 @@ function SwipeableTaskCard({
       translateX.removeListener(id);
     };
   }, [translateX]);
-
-  useEffect(() => {
-    setHasImageError(false);
-  }, [task.customImage]);
 
   const closeActions = useCallback(() => {
     Animated.spring(translateX, {
@@ -2467,137 +2451,6 @@ function SwipeableTaskCard({
     [closeActions]
   );
 
-  const totalLabel = useMemo(() => {
-    const quantumLabel = getQuantumProgressLabel(task);
-    if (quantumLabel) {
-      return quantumLabel;
-    }
-    if (!totalSubtasks) {
-      return null;
-    }
-    return `${completedSubtasks}/${totalSubtasks}`;
-  }, [completedSubtasks, task, totalSubtasks]);
-
-  const isQuantum = task.type === 'quantum';
-  const isWaterAnimation = task.quantum?.animation === 'water';
-  const waterPercent = useMemo(() => getQuantumProgressPercent(task), [task]);
-  const waveHeight = 34;
-  const updateWavePaths = useCallback(() => {
-    if (!cardSize.width) {
-      return;
-    }
-    const intensityValue = waveIntensityRef.current;
-    const phaseValue = wavePhaseRef.current;
-    const frontAmplitude = 6 + intensityValue * 2.5;
-    const backAmplitude = 4 + intensityValue * 1.6;
-    const frontPath = buildWavePath({
-      width: cardSize.width,
-      height: waveHeight,
-      amplitude: frontAmplitude,
-      phase: phaseValue,
-    });
-    const backPath = buildWavePath({
-      width: cardSize.width,
-      height: waveHeight,
-      amplitude: backAmplitude,
-      phase: phaseValue + Math.PI / 2,
-    });
-    setWavePathFront(frontPath);
-    setWavePathBack(backPath);
-  }, [cardSize.width, waveHeight]);
-  const waterFillHeight = useMemo(() => {
-    if (!cardSize.height) {
-      return 0;
-    }
-    return waterLevelAnim.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, cardSize.height],
-    });
-  }, [cardSize.height, waterLevelAnim]);
-
-  useEffect(() => {
-    if (!isQuantum || !isWaterAnimation) {
-      wavePhaseAnim.stopAnimation();
-      wavePhaseAnim.setValue(0);
-      return undefined;
-    }
-
-    const animationLoop = Animated.loop(
-      Animated.timing(wavePhaseAnim, {
-        toValue: Math.PI * 2,
-        duration: 3600,
-        easing: Easing.inOut(Easing.sin),
-        useNativeDriver: false,
-      })
-    );
-
-    animationLoop.start();
-    return () => {
-      animationLoop.stop();
-      wavePhaseAnim.setValue(0);
-    };
-  }, [isQuantum, isWaterAnimation, wavePhaseAnim]);
-
-  useEffect(() => {
-    const id = wavePhaseAnim.addListener(({ value }) => {
-      wavePhaseRef.current = value;
-      updateWavePaths();
-    });
-    const intensityId = waveIntensityAnim.addListener(({ value }) => {
-      waveIntensityRef.current = value;
-      const normalized = clamp01((value - 1) / 4);
-      setWaveColor(interpolateHexColor('#e9f5ff', '#c3e6ff', normalized));
-      updateWavePaths();
-    });
-    return () => {
-      wavePhaseAnim.removeListener(id);
-      waveIntensityAnim.removeListener(intensityId);
-    };
-  }, [updateWavePaths, waveIntensityAnim, wavePhaseAnim]);
-
-  useEffect(() => {
-    updateWavePaths();
-  }, [cardSize.width, updateWavePaths]);
-
-  useEffect(() => {
-    if (!isQuantum || !isWaterAnimation || !cardSize.height) {
-      return;
-    }
-    Animated.spring(waterLevelAnim, {
-      toValue: waterPercent,
-      damping: 10,
-      stiffness: 140,
-      mass: 0.9,
-      useNativeDriver: false,
-    }).start();
-  }, [cardSize.height, isQuantum, isWaterAnimation, waterLevelAnim, waterPercent]);
-
-  useEffect(() => {
-    if (!isQuantum || !isWaterAnimation || !task.quantum?.wavePulse) {
-      return;
-    }
-    waveIntensityAnim.stopAnimation();
-    waveIntensityAnim.setValue(1);
-    Animated.sequence([
-      Animated.spring(waveIntensityAnim, {
-        toValue: 4.8,
-        damping: 6,
-        stiffness: 180,
-        mass: 0.6,
-        useNativeDriver: false,
-      }),
-      Animated.spring(waveIntensityAnim, {
-        toValue: 1,
-        damping: 8,
-        stiffness: 120,
-        mass: 0.8,
-        useNativeDriver: false,
-      }),
-    ]).start();
-  }, [isQuantum, isWaterAnimation, task.quantum?.wavePulse, waveIntensityAnim]);
-  const toggleAction = isQuantum ? onAdjustQuantum : onToggleCompletion;
-  const isQuantumComplete = isQuantum && getQuantumProgressLabel(task) && task.completed;
-
   return (
     <View style={[styles.swipeableWrapper, { zIndex: isOpen ? 10 : 1 }]}>
       <View style={styles.swipeableActions}>
@@ -2633,94 +2486,19 @@ function SwipeableTaskCard({
           </Text>
         </TouchableOpacity>
       </View>
-      <Animated.View
-        {...panResponder.panHandlers}
-        style={[
-          styles.taskCard,
-          {
-            backgroundColor: backgroundColor || '#fff',
-            borderColor,
-            transform: [{ translateX }],
-          },
-        ]}
-        onLayout={(event) => {
-          const { width, height } = event.nativeEvent.layout;
-          setCardSize({ width, height });
-        }}
-      >
-        {isQuantum && isWaterAnimation && (
-          <View pointerEvents="none" style={styles.waterFillContainer}>
-            <AnimatedLinearGradient
-              colors={['rgba(107, 190, 255, 0.6)', 'rgba(64, 148, 255, 0.9)']}
-              start={{ x: 0.5, y: 0 }}
-              end={{ x: 0.5, y: 1 }}
-              style={[styles.waterFill, { height: waterFillHeight }]}
-            >
-              <Svg width={cardSize.width} height={waveHeight} style={styles.waterWaveSvg}>
-                {wavePathBack ? (
-                  <Path d={wavePathBack} fill={waveColor} opacity={0.55} />
-                ) : null}
-                {wavePathFront ? (
-                  <Path d={wavePathFront} fill="#f4fbff" opacity={0.8} />
-                ) : null}
-              </Svg>
-            </AnimatedLinearGradient>
-          </View>
-        )}
-        <Pressable style={styles.taskCardContent} onPress={handlePress}>
-          <View style={styles.taskInfo}>
-            {task.customImage && !hasImageError ? (
-              <Image
-                source={{ uri: task.customImage }}
-                style={styles.taskEmojiImage}
-                onError={() => setHasImageError(true)}
-              />
-            ) : (
-              <Text style={styles.taskEmoji}>{task.emoji || FALLBACK_EMOJI}</Text>
-            )}
-            <View style={styles.taskDetails}>
-              <Text
-                style={[styles.taskTitle, task.completed && styles.taskTitleCompleted]}
-                numberOfLines={1}
-              >
-                {task.title}
-              </Text>
-              <Text style={styles.taskTime}>{formatTaskTime(task.time)}</Text>
-              {totalLabel && (
-                <View style={styles.taskSubtaskSummary}>
-                  <Text style={styles.taskSubtaskSummaryText}>{totalLabel}</Text>
-                </View>
-              )}
-            </View>
-          </View>
-        </Pressable>
-        <Pressable
-          onPress={() => handleAction(toggleAction)}
-          style={[
-            styles.taskToggle,
-            (isQuantumComplete || (!isQuantum && task.completed)) && styles.taskToggleCompleted,
-          ]}
-          accessibilityRole={isQuantum ? 'button' : 'checkbox'}
-          accessibilityLabel={
-            isQuantum
-              ? 'Adjust quantum progress'
-              : task.completed
-              ? 'Mark task as incomplete'
-              : 'Mark task as complete'
-          }
-          accessibilityState={isQuantum ? undefined : { checked: task.completed }}
-        >
-          {isQuantum ? (
-            isQuantumComplete ? (
-              <Ionicons name="checkmark" size={18} color="#ffffff" />
-            ) : (
-              <Ionicons name="add" size={18} color="#1F2742" />
-            )
-          ) : (
-            task.completed && <Ionicons name="checkmark" size={18} color="#ffffff" />
-          )}
-        </Pressable>
-      </Animated.View>
+      <TaskCard
+        task={task}
+        backgroundColor={backgroundColor}
+        borderColor={borderColor}
+        totalSubtasks={totalSubtasks}
+        completedSubtasks={completedSubtasks}
+        onPress={handlePress}
+        onToggleCompletion={() => handleAction(onToggleCompletion)}
+        onAdjustQuantum={() => handleAction(onAdjustQuantum)}
+        ContainerComponent={Animated.View}
+        containerProps={panResponder.panHandlers}
+        containerStyle={{ transform: [{ translateX }] }}
+      />
     </View>
   );
 }

--- a/components/TaskCard.js
+++ b/components/TaskCard.js
@@ -1,0 +1,376 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Animated, Easing, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Svg, { Path } from 'react-native-svg';
+import { LinearGradient } from 'expo-linear-gradient';
+import { clamp01, interpolateHexColor, lightenColor } from '../utils/colorUtils';
+import { getQuantumProgressLabel, getQuantumProgressPercent } from '../utils/taskUtils';
+import { formatTaskTime } from '../utils/timeUtils';
+import { buildWavePath } from '../utils/waveUtils';
+
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+const FALLBACK_EMOJI = '⭐';
+
+function TaskCard({
+  task,
+  backgroundColor,
+  borderColor,
+  totalSubtasks = 0,
+  completedSubtasks = 0,
+  onPress,
+  onToggleCompletion,
+  onAdjustQuantum,
+  previewProgress,
+  previewLabel,
+  ContainerComponent = View,
+  containerStyle,
+  containerProps,
+  showToggle = true,
+}) {
+  const wavePhaseAnim = useRef(new Animated.Value(0)).current;
+  const waveIntensityAnim = useRef(new Animated.Value(1)).current;
+  const waterLevelAnim = useRef(new Animated.Value(0)).current;
+  const wavePhaseRef = useRef(0);
+  const waveIntensityRef = useRef(1);
+  const [cardSize, setCardSize] = useState({ width: 0, height: 0 });
+  const [wavePathFront, setWavePathFront] = useState('');
+  const [wavePathBack, setWavePathBack] = useState('');
+  const [waveColor, setWaveColor] = useState('#e9f5ff');
+  const [hasImageError, setHasImageError] = useState(false);
+
+  useEffect(() => {
+    setHasImageError(false);
+  }, [task.customImage]);
+
+  const totalLabel = useMemo(() => {
+    if (previewLabel) {
+      return previewLabel;
+    }
+    const quantumLabel = getQuantumProgressLabel(task);
+    if (quantumLabel) {
+      return quantumLabel;
+    }
+    if (!totalSubtasks) {
+      return null;
+    }
+    return `${completedSubtasks}/${totalSubtasks}`;
+  }, [completedSubtasks, previewLabel, task, totalSubtasks]);
+
+  const isQuantum = task.type === 'quantum';
+  const isWaterAnimation = task.quantum?.animation === 'water';
+  const waterPercent = useMemo(() => {
+    if (typeof previewProgress === 'number') {
+      return clamp01(previewProgress);
+    }
+    return getQuantumProgressPercent(task);
+  }, [previewProgress, task]);
+  const waveHeight = 34;
+  const updateWavePaths = useCallback(() => {
+    if (!cardSize.width) {
+      return;
+    }
+    const intensityValue = waveIntensityRef.current;
+    const phaseValue = wavePhaseRef.current;
+    const frontAmplitude = 6 + intensityValue * 2.5;
+    const backAmplitude = 4 + intensityValue * 1.6;
+    const frontPath = buildWavePath({
+      width: cardSize.width,
+      height: waveHeight,
+      amplitude: frontAmplitude,
+      phase: phaseValue,
+    });
+    const backPath = buildWavePath({
+      width: cardSize.width,
+      height: waveHeight,
+      amplitude: backAmplitude,
+      phase: phaseValue + Math.PI / 2,
+    });
+    setWavePathFront(frontPath);
+    setWavePathBack(backPath);
+  }, [cardSize.width, waveHeight]);
+  const waterFillHeight = useMemo(() => {
+    if (!cardSize.height) {
+      return 0;
+    }
+    return waterLevelAnim.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, cardSize.height],
+    });
+  }, [cardSize.height, waterLevelAnim]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation) {
+      wavePhaseAnim.stopAnimation();
+      wavePhaseAnim.setValue(0);
+      return undefined;
+    }
+
+    const animationLoop = Animated.loop(
+      Animated.timing(wavePhaseAnim, {
+        toValue: Math.PI * 2,
+        duration: 3600,
+        easing: Easing.inOut(Easing.sin),
+        useNativeDriver: false,
+      })
+    );
+
+    animationLoop.start();
+    return () => {
+      animationLoop.stop();
+      wavePhaseAnim.setValue(0);
+    };
+  }, [isQuantum, isWaterAnimation, wavePhaseAnim]);
+
+  useEffect(() => {
+    const id = wavePhaseAnim.addListener(({ value }) => {
+      wavePhaseRef.current = value;
+      updateWavePaths();
+    });
+    const intensityId = waveIntensityAnim.addListener(({ value }) => {
+      waveIntensityRef.current = value;
+      const normalized = clamp01((value - 1) / 4);
+      setWaveColor(interpolateHexColor('#e9f5ff', '#c3e6ff', normalized));
+      updateWavePaths();
+    });
+    return () => {
+      wavePhaseAnim.removeListener(id);
+      waveIntensityAnim.removeListener(intensityId);
+    };
+  }, [updateWavePaths, waveIntensityAnim, wavePhaseAnim]);
+
+  useEffect(() => {
+    updateWavePaths();
+  }, [cardSize.width, updateWavePaths]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation || !cardSize.height) {
+      return;
+    }
+    Animated.spring(waterLevelAnim, {
+      toValue: waterPercent,
+      damping: 10,
+      stiffness: 140,
+      mass: 0.9,
+      useNativeDriver: false,
+    }).start();
+  }, [cardSize.height, isQuantum, isWaterAnimation, waterLevelAnim, waterPercent]);
+
+  useEffect(() => {
+    if (!isQuantum || !isWaterAnimation || !task.quantum?.wavePulse) {
+      return;
+    }
+    waveIntensityAnim.stopAnimation();
+    waveIntensityAnim.setValue(1);
+    Animated.sequence([
+      Animated.spring(waveIntensityAnim, {
+        toValue: 4.8,
+        damping: 6,
+        stiffness: 180,
+        mass: 0.6,
+        useNativeDriver: false,
+      }),
+      Animated.spring(waveIntensityAnim, {
+        toValue: 1,
+        damping: 8,
+        stiffness: 120,
+        mass: 0.8,
+        useNativeDriver: false,
+      }),
+    ]).start();
+  }, [isQuantum, isWaterAnimation, task.quantum?.wavePulse, waveIntensityAnim]);
+
+  const toggleAction = isQuantum ? onAdjustQuantum : onToggleCompletion;
+  const isQuantumComplete = isQuantum && getQuantumProgressLabel(task) && task.completed;
+
+  return (
+    <ContainerComponent
+      {...containerProps}
+      style={[
+        styles.taskCard,
+        containerStyle,
+        {
+          backgroundColor: backgroundColor || '#fff',
+          borderColor: borderColor || lightenColor(task.color ?? '#ffffff', 0.1),
+        },
+      ]}
+      onLayout={(event) => {
+        const { width, height } = event.nativeEvent.layout;
+        setCardSize({ width, height });
+      }}
+    >
+      {isQuantum && isWaterAnimation && (
+        <View pointerEvents="none" style={styles.waterFillContainer}>
+          <AnimatedLinearGradient
+            colors={['rgba(107, 190, 255, 0.6)', 'rgba(64, 148, 255, 0.9)']}
+            start={{ x: 0.5, y: 0 }}
+            end={{ x: 0.5, y: 1 }}
+            style={[styles.waterFill, { height: waterFillHeight }]}
+          >
+            <Svg width={cardSize.width} height={waveHeight} style={styles.waterWaveSvg}>
+              {wavePathBack ? <Path d={wavePathBack} fill={waveColor} opacity={0.55} /> : null}
+              {wavePathFront ? <Path d={wavePathFront} fill="#f4fbff" opacity={0.8} /> : null}
+            </Svg>
+          </AnimatedLinearGradient>
+        </View>
+      )}
+      <Pressable style={styles.taskCardContent} onPress={onPress}>
+        <View style={styles.taskInfo}>
+          {task.customImage && !hasImageError ? (
+            <Image
+              source={{ uri: task.customImage }}
+              style={styles.taskEmojiImage}
+              onError={() => setHasImageError(true)}
+            />
+          ) : (
+            <Text style={styles.taskEmoji}>{task.emoji || FALLBACK_EMOJI}</Text>
+          )}
+          <View style={styles.taskDetails}>
+            <Text
+              style={[styles.taskTitle, task.completed && styles.taskTitleCompleted]}
+              numberOfLines={1}
+            >
+              {task.title}
+            </Text>
+            <Text style={styles.taskTime}>{formatTaskTime(task.time)}</Text>
+            {totalLabel && (
+              <View style={styles.taskSubtaskSummary}>
+                <Text style={styles.taskSubtaskSummaryText}>{totalLabel}</Text>
+              </View>
+            )}
+          </View>
+        </View>
+      </Pressable>
+      {showToggle ? (
+        <Pressable
+          onPress={toggleAction}
+          style={[
+            styles.taskToggle,
+            (isQuantumComplete || (!isQuantum && task.completed)) && styles.taskToggleCompleted,
+          ]}
+          accessibilityRole={isQuantum ? 'button' : 'checkbox'}
+          accessibilityLabel={
+            isQuantum
+              ? 'Adjust quantum progress'
+              : task.completed
+              ? 'Mark task as incomplete'
+              : 'Mark task as complete'
+          }
+          accessibilityState={isQuantum ? undefined : { checked: task.completed }}
+        >
+          {isQuantum ? (
+            isQuantumComplete ? (
+              <Ionicons name="checkmark" size={18} color="#ffffff" />
+            ) : (
+              <Ionicons name="add" size={18} color="#1F2742" />
+            )
+          ) : (
+            task.completed && <Ionicons name="checkmark" size={18} color="#ffffff" />
+          )}
+        </Pressable>
+      ) : null}
+    </ContainerComponent>
+  );
+}
+
+const styles = StyleSheet.create({
+  taskCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    overflow: 'hidden',
+    backgroundColor: '#ffffff',
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  waterFillContainer: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 18,
+    overflow: 'hidden',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  },
+  waterFill: {
+    width: '100%',
+    position: 'relative',
+  },
+  waterWaveSvg: {
+    position: 'absolute',
+    top: -18,
+    left: 0,
+    right: 0,
+  },
+  taskInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  taskCardContent: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  taskEmoji: {
+    fontSize: 34,
+  },
+  taskEmojiImage: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    resizeMode: 'cover',
+  },
+  taskDetails: {
+    marginLeft: 12,
+    flex: 1,
+  },
+  taskTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1a1a2e',
+  },
+  taskTitleCompleted: {
+    color: '#6f7a86',
+    textDecorationLine: 'line-through',
+  },
+  taskTime: {
+    marginTop: 4,
+    fontSize: 13,
+    color: '#6f7a86',
+  },
+  taskSubtaskSummary: {
+    marginTop: 6,
+    alignSelf: 'flex-start',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#d7dbeb',
+  },
+  taskSubtaskSummaryText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#3c2ba7',
+  },
+  taskToggle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: '#c5cadb',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+  },
+  taskToggleCompleted: {
+    backgroundColor: '#3dd598',
+    borderColor: '#3dd598',
+  },
+});
+
+export default TaskCard;


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc preview card implementation with the real task card so previews exactly match production cards.
- Make the quantum `water` animation and fill visible in previews by reusing the same rendering and sizing logic used by list cards.
- Eliminate duplicated wave/animation logic and keep swipeable list cards and the sheet/overlay previews consistent.
- Simplify code and reduce maintenance surface by centralizing card UI in a single component.

### Description
- Added a new `components/TaskCard.js` component that implements the production card layout, the water animated gradient and SVG wave rendering, and props for preview state (`previewProgress`, `previewLabel`).
- Refactored `SwipeableTaskCard` in `App.js` to render `TaskCard` (using `ContainerComponent={Animated.View}` and passing pan handlers) so list items reuse the same UI and animation code.
- Replaced the previous preview card implementations in `components/AddHabitSheet.js` and `QuantumPanel` with `TaskCard` instances for both `quantum` and `default` types, passing a 50% preview progress and computed preview label via `getQuantumPreviewLabel`.
- Removed duplicated preview styles and unused wave/animation variables/imports from the previous implementations and performed minor cleanup of related imports.

### Testing
- No automated unit or integration tests were run for these UI changes.
- No CI or test pipeline executions were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9252cc54832695f38dcd348b657d)