### PR TITLE
Show quantum preview water animation

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -3,6 +3,7 @@ import {
   AccessibilityInfo,
   Animated,
   BackHandler,
+  Easing,
   Image,
   KeyboardAvoidingView,
   PanResponder,
@@ -18,14 +19,20 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
+import Svg, { Path } from 'react-native-svg';
+import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import * as ImagePicker from 'expo-image-picker';
+import { formatTaskTime } from '../utils/timeUtils';
+import { getQuantumProgressLabel, getQuantumProgressPercent } from '../utils/taskUtils';
+import { buildWavePath } from '../utils/waveUtils';
 
 const SHEET_OPEN_DURATION = 300;
 const SHEET_CLOSE_DURATION = 220;
 const BACKDROP_MAX_OPACITY = 0.5;
 const USE_NATIVE_DRIVER = Platform.OS !== 'web';
 const HAPTICS_SUPPORTED = Platform.OS === 'ios' || Platform.OS === 'android';
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
 
 const COLORS = ['#FFCF70', '#F7A6A1', '#B39DD6', '#79C3FF', '#A8E6CF', '#FDE2A6'];
 const EMOJIS = [
@@ -1281,6 +1288,157 @@ export default function AddHabitSheet({
     pendingHasSpecifiedTime,
     pendingTimeMode,
   ]);
+  const previewTitle = useMemo(
+    () => (title.trim() ? title.trim() : 'Untitled task'),
+    [title]
+  );
+  const previewTimeLabel = useMemo(
+    () =>
+      formatTaskTime({
+        specified: hasSpecifiedTime,
+        mode: timeMode,
+        point: normalizedPointTime,
+        period: normalizedPeriodTime,
+      }),
+    [hasSpecifiedTime, normalizedPeriodTime, normalizedPointTime, timeMode]
+  );
+  const previewQuantum = useMemo(() => {
+    const minutes = Number.parseInt(pendingQuantumTimerMinutes, 10) || 0;
+    const seconds = Number.parseInt(pendingQuantumTimerSeconds, 10) || 0;
+    const totalSeconds = minutes * 60 + seconds;
+    const limitValue = Number.parseInt(pendingQuantumCountValue, 10) || 0;
+    const halfSeconds = totalSeconds ? Math.max(1, Math.floor(totalSeconds / 2)) : 0;
+    const halfCount = limitValue ? Math.max(1, Math.floor(limitValue / 2)) : 0;
+
+    return {
+      mode: pendingQuantumMode,
+      animation: pendingQuantumAnimation,
+      timer: {
+        minutes,
+        seconds,
+      },
+      count: {
+        value: limitValue,
+        unit: pendingQuantumCountUnit.trim(),
+      },
+      doneSeconds: pendingQuantumMode === 'timer' ? halfSeconds : 0,
+      doneCount: pendingQuantumMode === 'count' ? halfCount : 0,
+    };
+  }, [
+    pendingQuantumAnimation,
+    pendingQuantumCountUnit,
+    pendingQuantumCountValue,
+    pendingQuantumMode,
+    pendingQuantumTimerMinutes,
+    pendingQuantumTimerSeconds,
+  ]);
+  const previewSummary = useMemo(() => {
+    if (pendingType === 'quantum') {
+      return getQuantumProgressLabel({ type: 'quantum', quantum: previewQuantum });
+    }
+    if (!subtasks.length) {
+      return null;
+    }
+    return `0/${subtasks.length}`;
+  }, [pendingType, previewQuantum, subtasks.length]);
+  const [previewCardSize, setPreviewCardSize] = useState({ width: 0, height: 0 });
+  const previewWavePhaseAnim = useRef(new Animated.Value(0)).current;
+  const previewWaterLevelAnim = useRef(new Animated.Value(0)).current;
+  const previewWavePhaseRef = useRef(0);
+  const [previewWavePathFront, setPreviewWavePathFront] = useState('');
+  const [previewWavePathBack, setPreviewWavePathBack] = useState('');
+  const previewWaveHeight = 34;
+  const isPreviewWater = pendingType === 'quantum' && pendingQuantumAnimation === 'water';
+  const previewTask = useMemo(
+    () => ({
+      type: pendingType,
+      quantum: previewQuantum,
+    }),
+    [pendingType, previewQuantum]
+  );
+  const previewWaterPercent = useMemo(
+    () => getQuantumProgressPercent(previewTask),
+    [previewTask]
+  );
+  const previewWaterFillHeight = useMemo(() => {
+    if (!previewCardSize.height) {
+      return 0;
+    }
+    return previewWaterLevelAnim.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, previewCardSize.height],
+    });
+  }, [previewCardSize.height, previewWaterLevelAnim]);
+  const updatePreviewWavePaths = useCallback(() => {
+    if (!previewCardSize.width) {
+      return;
+    }
+    const phaseValue = previewWavePhaseRef.current;
+    const frontPath = buildWavePath({
+      width: previewCardSize.width,
+      height: previewWaveHeight,
+      amplitude: 6,
+      phase: phaseValue,
+    });
+    const backPath = buildWavePath({
+      width: previewCardSize.width,
+      height: previewWaveHeight,
+      amplitude: 4,
+      phase: phaseValue + Math.PI / 2,
+    });
+    setPreviewWavePathFront(frontPath);
+    setPreviewWavePathBack(backPath);
+  }, [previewCardSize.width, previewWaveHeight]);
+
+  useEffect(() => {
+    if (!isPreviewWater) {
+      previewWavePhaseAnim.stopAnimation();
+      previewWavePhaseAnim.setValue(0);
+      return undefined;
+    }
+    const animationLoop = Animated.loop(
+      Animated.timing(previewWavePhaseAnim, {
+        toValue: Math.PI * 2,
+        duration: 3600,
+        easing: Easing.inOut(Easing.sin),
+        useNativeDriver: false,
+      })
+    );
+    animationLoop.start();
+    return () => {
+      animationLoop.stop();
+      previewWavePhaseAnim.setValue(0);
+    };
+  }, [isPreviewWater, previewWavePhaseAnim]);
+
+  useEffect(() => {
+    const id = previewWavePhaseAnim.addListener(({ value }) => {
+      previewWavePhaseRef.current = value;
+      updatePreviewWavePaths();
+    });
+    return () => {
+      previewWavePhaseAnim.removeListener(id);
+    };
+  }, [previewWavePhaseAnim, updatePreviewWavePaths]);
+
+  useEffect(() => {
+    updatePreviewWavePaths();
+  }, [previewCardSize.width, updatePreviewWavePaths]);
+
+  useEffect(() => {
+    if (!isPreviewWater || !previewCardSize.height) {
+      previewWaterLevelAnim.stopAnimation();
+      previewWaterLevelAnim.setValue(0);
+      return;
+    }
+    Animated.spring(previewWaterLevelAnim, {
+      toValue: previewWaterPercent,
+      damping: 10,
+      stiffness: 140,
+      mass: 0.9,
+      useNativeDriver: false,
+    }).start();
+  }, [isPreviewWater, previewCardSize.height, previewWaterLevelAnim, previewWaterPercent]);
 
   if (!isMounted) {
     return null;
@@ -1689,6 +1847,62 @@ export default function AddHabitSheet({
                     />
                   </>
                 )}
+                <View style={styles.typePreviewSection}>
+                  <Text style={styles.typePreviewLabel}>Preview</Text>
+                  <View
+                    style={[
+                      styles.typePreviewCard,
+                      { backgroundColor: sheetBackgroundColor, borderColor: selectedColor },
+                    ]}
+                    onLayout={(event) => {
+                      const { width, height } = event.nativeEvent.layout;
+                      setPreviewCardSize({ width, height });
+                    }}
+                  >
+                    {isPreviewWater && (
+                      <View pointerEvents="none" style={styles.typePreviewWaterFillContainer}>
+                        <AnimatedLinearGradient
+                          colors={['rgba(107, 190, 255, 0.6)', 'rgba(64, 148, 255, 0.9)']}
+                          start={{ x: 0.5, y: 0 }}
+                          end={{ x: 0.5, y: 1 }}
+                          style={[styles.typePreviewWaterFill, { height: previewWaterFillHeight }]}
+                        >
+                          <Svg
+                            width={previewCardSize.width}
+                            height={previewWaveHeight}
+                            style={styles.typePreviewWaterWave}
+                          >
+                            {previewWavePathBack ? (
+                              <Path d={previewWavePathBack} fill="#e9f5ff" opacity={0.55} />
+                            ) : null}
+                            {previewWavePathFront ? (
+                              <Path d={previewWavePathFront} fill="#f4fbff" opacity={0.8} />
+                            ) : null}
+                          </Svg>
+                        </AnimatedLinearGradient>
+                      </View>
+                    )}
+                    <View style={styles.typePreviewInfo}>
+                      {customImage ? (
+                        <Image source={{ uri: customImage }} style={styles.typePreviewEmojiImage} />
+                      ) : (
+                        <Text style={styles.typePreviewEmoji}>{selectedEmoji || DEFAULT_EMOJI}</Text>
+                      )}
+                      <View style={styles.typePreviewDetails}>
+                        <Text style={styles.typePreviewTitle} numberOfLines={1}>
+                          {previewTitle}
+                        </Text>
+                        <Text style={styles.typePreviewTime}>{previewTimeLabel}</Text>
+                        {previewSummary ? (
+                          <View style={styles.typePreviewSummary}>
+                            <Text style={styles.typePreviewSummaryText}>{previewSummary}</Text>
+                          </View>
+                        ) : null}
+                      </View>
+                    </View>
+                    <View style={styles.typePreviewToggle} />
+                  </View>
+                </View>
               </OptionOverlay>
             )}
           </View>
@@ -3149,6 +3363,102 @@ const styles = StyleSheet.create({
     backgroundColor: '#F5F7FF',
     borderRadius: 20,
     overflow: 'hidden',
+  },
+  typePreviewSection: {
+    marginTop: 24,
+    gap: 10,
+  },
+  typePreviewLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.6,
+    color: '#7F8A9A',
+    textTransform: 'uppercase',
+  },
+  typePreviewCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 18,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+    backgroundColor: '#FFFFFF',
+    elevation: 4,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  typePreviewWaterFillContainer: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 18,
+    overflow: 'hidden',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  },
+  typePreviewWaterFill: {
+    width: '100%',
+    position: 'relative',
+  },
+  typePreviewWaterWave: {
+    position: 'absolute',
+    top: -18,
+    left: 0,
+    right: 0,
+  },
+  typePreviewInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  typePreviewEmoji: {
+    fontSize: 34,
+  },
+  typePreviewEmojiImage: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    resizeMode: 'cover',
+  },
+  typePreviewDetails: {
+    marginLeft: 12,
+    flex: 1,
+  },
+  typePreviewTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1a1a2e',
+  },
+  typePreviewTime: {
+    marginTop: 4,
+    fontSize: 13,
+    color: '#6f7a86',
+  },
+  typePreviewSummary: {
+    marginTop: 6,
+    alignSelf: 'flex-start',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#d7dbeb',
+  },
+  typePreviewSummaryText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#3c2ba7',
+  },
+  typePreviewToggle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: '#c5cadb',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
   },
   tagPanel: {
     gap: 18,


### PR DESCRIPTION
### Motivation
- Make the `Type` panel preview show the water animation for quantum tasks so users can see the fill effect while configuring a task. 
- Ensure the preview visually represents the card shown in list/detail views when `water` animation is selected. 

### Description
- Drive preview quantum progress to a half-completed state by computing `previewQuantum` with `doneSeconds` / `doneCount` set to ~50% so the animation and water fill are visible. 
- Add a wave overlay to the preview card using `AnimatedLinearGradient`, `react-native-svg` `Path` and `buildWavePath`, and animate phase and water level with `Animated` hooks. 
- Import `getQuantumProgressPercent`, `buildWavePath`, `Easing` and `LinearGradient`, create `AnimatedLinearGradient`, and add rendering + lifecycle logic and styles inside `components/AddHabitSheet.js`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e64a73860832697f8ae8302ca29fa)