### PR TITLE
Fix profile stats grid layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,6 +32,7 @@ import * as FileSystem from 'expo-file-system/legacy';
 import {
   addMonths as addMonthsDateFns,
   eachDayOfInterval,
+  differenceInCalendarDays,
   endOfMonth,
   endOfWeek,
   format,
@@ -890,6 +891,70 @@ function ScheduleApp() {
     () => tasks.find((task) => task.id === activeProfileTaskId) ?? null,
     [activeProfileTaskId, tasks]
   );
+  const profileStats = useMemo(() => {
+    const committedHabits = tasks.length;
+    const dateCandidates = [];
+
+    history.forEach((entry) => {
+      if (entry?.timestamp) {
+        const normalized = normalizeDateValue(entry.timestamp);
+        if (normalized) {
+          dateCandidates.push(normalized);
+        }
+      }
+    });
+
+    tasks.forEach((task) => {
+      const normalized = normalizeDateValue(task.date ?? task.dateKey);
+      if (normalized) {
+        dateCandidates.push(normalized);
+      }
+    });
+
+    const minDate = dateCandidates.length
+      ? new Date(Math.min(...dateCandidates.map((date) => date.getTime())))
+      : today;
+    const startDate = minDate > today ? today : minDate;
+    const totalDays = Math.max(0, differenceInCalendarDays(today, startDate) + 1);
+
+    if (!tasks.length) {
+      return {
+        totalDays,
+        committedHabits,
+        currentStreak: 0,
+        bestStreak: 0,
+      };
+    }
+
+    const dateRange = eachDayOfInterval({ start: startDate, end: today });
+    let currentStreak = 0;
+    let bestStreak = 0;
+
+    dateRange.forEach((date) => {
+      const scheduledTasks = tasks.filter((task) => shouldTaskAppearOnDate(task, date));
+      if (scheduledTasks.length === 0) {
+        return;
+      }
+      const isComplete = scheduledTasks.every((task) => getTaskCompletionStatus(task, date));
+      if (isComplete) {
+        currentStreak += 1;
+        bestStreak = Math.max(bestStreak, currentStreak);
+      } else {
+        currentStreak = 0;
+      }
+    });
+
+    return {
+      totalDays,
+      committedHabits,
+      currentStreak,
+      bestStreak,
+    };
+  }, [history, tasks, today]);
+  const totalDaysUnit = profileStats.totalDays === 1 ? 'day' : 'days';
+  const habitsUnit = profileStats.committedHabits === 1 ? 'habit' : 'habits';
+  const currentStreakUnit = profileStats.currentStreak === 1 ? 'day' : 'days';
+  const bestStreakUnit = profileStats.bestStreak === 1 ? 'day' : 'days';
   const activeTaskForSelectedDate = useMemo(
     () =>
       activeTask
@@ -1989,6 +2054,40 @@ function ScheduleApp() {
                 <Text style={styles.profileSubtitle}>
                   Personalize your experience and tweak how your calendar looks.
                 </Text>
+
+                <View style={styles.profileStatsSection}>
+                  <Text style={styles.profileStatsTitle}>Stats</Text>
+                  <View style={styles.profileStatsGrid}>
+                    <View style={styles.profileStatCard}>
+                      <Text style={styles.profileStatLabel}>Total days</Text>
+                      <View style={styles.profileStatValueRow}>
+                        <Text style={styles.profileStatValue}>{profileStats.totalDays}</Text>
+                        <Text style={styles.profileStatUnit}>{totalDaysUnit}</Text>
+                      </View>
+                    </View>
+                    <View style={styles.profileStatCard}>
+                      <Text style={styles.profileStatLabel}>Committed habits</Text>
+                      <View style={styles.profileStatValueRow}>
+                        <Text style={styles.profileStatValue}>{profileStats.committedHabits}</Text>
+                        <Text style={styles.profileStatUnit}>{habitsUnit}</Text>
+                      </View>
+                    </View>
+                    <View style={styles.profileStatCard}>
+                      <Text style={styles.profileStatLabel}>Current streak</Text>
+                      <View style={styles.profileStatValueRow}>
+                        <Text style={styles.profileStatValue}>{profileStats.currentStreak}</Text>
+                        <Text style={styles.profileStatUnit}>{currentStreakUnit}</Text>
+                      </View>
+                    </View>
+                    <View style={styles.profileStatCard}>
+                      <Text style={styles.profileStatLabel}>Best streak</Text>
+                      <View style={styles.profileStatValueRow}>
+                        <Text style={styles.profileStatValue}>{profileStats.bestStreak}</Text>
+                        <Text style={styles.profileStatUnit}>{bestStreakUnit}</Text>
+                      </View>
+                    </View>
+                  </View>
+                </View>
 
                 <TouchableOpacity
                   style={styles.customizeButton}
@@ -4557,6 +4656,51 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 32,
     lineHeight: 22,
+  },
+  profileStatsSection: {
+    alignSelf: 'stretch',
+    marginBottom: 28,
+  },
+  profileStatsTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#1a1a2e',
+    marginBottom: 12,
+  },
+  profileStatsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  },
+  profileStatCard: {
+    width: '48%',
+    borderRadius: 20,
+    backgroundColor: '#f7f7fb',
+    padding: 16,
+    marginBottom: 12,
+  },
+  profileStatLabel: {
+    fontSize: 12,
+    color: '#6f7a86',
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 8,
+  },
+  profileStatValueRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+  },
+  profileStatValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#1a1a2e',
+  },
+  profileStatUnit: {
+    fontSize: 14,
+    color: '#6f7a86',
+    fontWeight: '600',
   },
   customizeButton: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
- Ensure the profile statistics render as a 2x2 matrix with consistent spacing between cards. 
- Replace the unsupported row `gap` spacing with layout-friendly margins to keep cross-platform behavior stable. 
- Keep the existing profile action buttons (`Customize Calendar` and `Open tasks`) visible and correctly positioned below the stats. 

### Description
- Updated `App.js` styles to make the stats grid a true two-column layout by changing `profileStatsGrid` to use `justifyContent: 'space-between'` instead of `gap` and setting each card width to `width: '48%'`.
- Replaced prior flexible basis/grow rules with fixed card widths and added `marginBottom: 12` on `profileStatCard` to restore vertical spacing between rows.
- The profile stats UI and the `profileStats` `useMemo` calculation remain in place, and the `Customize Calendar` and `Open tasks` buttons were preserved below the stats block.

### Testing
- No automated tests were executed for this change.
- No CI runs were recorded for this change.
- Manual verification was not recorded as an automated test.
- Visual/layout behavior was adjusted based on the reported layout issue (2x2 grid expectation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebef816988326b654ce8997053a52)