### PR TITLE
Fix daily quantum progress tracking

### DIFF
--- a/utils/taskUtils.js
+++ b/utils/taskUtils.js
@@ -40,7 +40,31 @@ const getSubtaskCompletionStatus = (subtask, dateKey) => {
   return Boolean(subtask.completed);
 };
 
-const getQuantumProgressLabel = (task) => {
+const getQuantumProgressValues = (task, dateKey) => {
+  if (!task || task.type !== 'quantum' || !task.quantum) {
+    return { doneSeconds: 0, doneCount: 0 };
+  }
+  if (dateKey) {
+    const progressByDate = task.quantum.progressByDate;
+    if (progressByDate && typeof progressByDate === 'object' && !Array.isArray(progressByDate)) {
+      const entry = progressByDate[dateKey];
+      if (entry && typeof entry === 'object') {
+        return {
+          doneSeconds: typeof entry.doneSeconds === 'number' ? entry.doneSeconds : 0,
+          doneCount: typeof entry.doneCount === 'number' ? entry.doneCount : 0,
+        };
+      }
+    }
+    return { doneSeconds: 0, doneCount: 0 };
+  }
+
+  return {
+    doneSeconds: typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0,
+    doneCount: typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0,
+  };
+};
+
+const getQuantumProgressLabel = (task, dateKey) => {
   if (!task || task.type !== 'quantum' || !task.quantum) {
     return null;
   }
@@ -52,8 +76,7 @@ const getQuantumProgressLabel = (task) => {
     if (!limitSeconds) {
       return null;
     }
-    const doneSeconds =
-      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    const { doneSeconds } = getQuantumProgressValues(task, dateKey);
     return `${formatDuration(doneSeconds)}/${formatDuration(limitSeconds)}`;
   }
   if (mode === 'count') {
@@ -62,14 +85,13 @@ const getQuantumProgressLabel = (task) => {
       return null;
     }
     const unit = task.quantum.count?.unit?.trim() ?? '';
-    const doneValue =
-      typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
-    return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
+    const { doneCount } = getQuantumProgressValues(task, dateKey);
+    return `${doneCount}/${limitValue}${unit ? ` ${unit}` : ''}`;
   }
   return null;
 };
 
-const getQuantumProgressPercent = (task) => {
+const getQuantumProgressPercent = (task, dateKey) => {
   if (!task || task.type !== 'quantum' || !task.quantum) {
     return 0;
   }
@@ -81,8 +103,7 @@ const getQuantumProgressPercent = (task) => {
     if (!totalSeconds) {
       return 0;
     }
-    const doneSeconds =
-      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    const { doneSeconds } = getQuantumProgressValues(task, dateKey);
     return clamp01(doneSeconds / totalSeconds);
   }
 
@@ -91,7 +112,7 @@ const getQuantumProgressPercent = (task) => {
     if (!limitValue) {
       return 0;
     }
-    const doneCount = typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
+    const { doneCount } = getQuantumProgressValues(task, dateKey);
     return clamp01(doneCount / limitValue);
   }
 


### PR DESCRIPTION
### Motivation
- Quantum task progress was stored as global `doneSeconds/doneCount`, causing completions done on one day to appear on subsequent days instead of resetting per-day.
- The intent is to track quantum progress per date so each day starts at zero until the user records progress for that day.

### Description
- Persist per-day quantum progress in a new `quantum.progressByDate` map and migrate legacy `doneSeconds`/`doneCount` into the entry for the task's base date during hydration using `normalizeStoredTasks`.
- Introduced `getQuantumProgressValues(task, dateKey)` and updated `getQuantumProgressLabel`/`getQuantumProgressPercent` to accept a `dateKey` and read per-day progress.
- Updated the quantum adjustment flow to read/write progress into `quantum.progressByDate[dateKey]` and to update `completedDates` per-day when limits are reached.
- Updated UI surfaces (`SwipeableTaskCard`, `DayReportModal`, `TaskDetailModal`, `QuantumAdjustModal`, list rendering) to pass the selected/date-specific `dateKey` so labels, percentages and adjustments reflect daily progress.

### Testing
- No automated tests were executed as part of this change.
- Manual playground verification was implied by UI wiring but not recorded as an automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa7a467d88326b8a6de0e8e135670)