### PR TITLE
Add quantum adjust presets and remember last-used count

### DIFF
--- a/utils/taskUtils.js
+++ b/utils/taskUtils.js
@@ -40,7 +40,31 @@ const getSubtaskCompletionStatus = (subtask, dateKey) => {
   return Boolean(subtask.completed);
 };
 
-const getQuantumProgressLabel = (task) => {
+const getQuantumProgressValues = (task, dateKey) => {
+  if (!task || task.type !== 'quantum' || !task.quantum) {
+    return { doneSeconds: 0, doneCount: 0 };
+  }
+  if (dateKey) {
+    const progressByDate = task.quantum.progressByDate;
+    if (progressByDate && typeof progressByDate === 'object' && !Array.isArray(progressByDate)) {
+      const entry = progressByDate[dateKey];
+      if (entry && typeof entry === 'object') {
+        return {
+          doneSeconds: typeof entry.doneSeconds === 'number' ? entry.doneSeconds : 0,
+          doneCount: typeof entry.doneCount === 'number' ? entry.doneCount : 0,
+        };
+      }
+    }
+    return { doneSeconds: 0, doneCount: 0 };
+  }
+
+  return {
+    doneSeconds: typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0,
+    doneCount: typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0,
+  };
+};
+
+const getQuantumProgressLabel = (task, dateKey) => {
   if (!task || task.type !== 'quantum' || !task.quantum) {
     return null;
   }
@@ -52,8 +76,7 @@ const getQuantumProgressLabel = (task) => {
     if (!limitSeconds) {
       return null;
     }
-    const doneSeconds =
-      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    const { doneSeconds } = getQuantumProgressValues(task, dateKey);
     return `${formatDuration(doneSeconds)}/${formatDuration(limitSeconds)}`;
   }
   if (mode === 'count') {
@@ -62,14 +85,13 @@ const getQuantumProgressLabel = (task) => {
       return null;
     }
     const unit = task.quantum.count?.unit?.trim() ?? '';
-    const doneValue =
-      typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
-    return `${doneValue}/${limitValue}${unit ? ` ${unit}` : ''}`;
+    const { doneCount } = getQuantumProgressValues(task, dateKey);
+    return `${doneCount}/${limitValue}${unit ? ` ${unit}` : ''}`;
   }
   return null;
 };
 
-const getQuantumProgressPercent = (task) => {
+const getQuantumProgressPercent = (task, dateKey) => {
   if (!task || task.type !== 'quantum' || !task.quantum) {
     return 0;
   }
@@ -81,8 +103,7 @@ const getQuantumProgressPercent = (task) => {
     if (!totalSeconds) {
       return 0;
     }
-    const doneSeconds =
-      typeof task.quantum.doneSeconds === 'number' ? task.quantum.doneSeconds : 0;
+    const { doneSeconds } = getQuantumProgressValues(task, dateKey);
     return clamp01(doneSeconds / totalSeconds);
   }
 
@@ -91,7 +112,7 @@ const getQuantumProgressPercent = (task) => {
     if (!limitValue) {
       return 0;
     }
-    const doneCount = typeof task.quantum.doneCount === 'number' ? task.quantum.doneCount : 0;
+    const { doneCount } = getQuantumProgressValues(task, dateKey);
     return clamp01(doneCount / limitValue);
   }
 


### PR DESCRIPTION
### Motivation
- Users reported the `Amount` field in the quantum adjust dialog always defaulted to `1` and wanted quick presets (last, half, max) for easier adjustments.
- The UI should match existing +/- button styling and be compact (single-line presets above the `Amount` input).
- Preserve per-day quantum progress semantics so adjustments apply to the selected date rather than a global counter.

### Description
- Persist the last used count per task by writing `quantum.lastAdjustCount` when applying count adjustments and use it to prefill the adjust dialog via `openQuantumAdjust` and `setQuantumAdjustCount`.
- Added a compact preset row to `QuantumAdjustModal` with three `Pressable` buttons for `last`, `half`, and `max` that update the `Amount` input via `handlePresetSelect` and visually indicate selection via new styles (`quantumModalPreset*`).
- Threaded `dateKey` through UI surfaces (`DayReportModal`, `SwipeableTaskCard`, `TaskDetailModal`, `QuantumAdjustModal`) and updated quantum helpers to support per-date progress via a new `getQuantumProgressValues(task, dateKey)` and by passing `dateKey` into `getQuantumProgressLabel`/`getQuantumProgressPercent`.
- Updated the quantum adjustment flow to read/write `progressByDate[dateKey]` for `doneCount`/`doneSeconds` and to update `completedDates` per-day.

### Testing
- No automated tests were executed for this change.
- (No automated test failures reported.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa7a467d88326b8a6de0e8e135670)