### PR TITLE
Prefer task dateKey when scheduling tasks

### DIFF
--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -109,7 +109,7 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
   }
 
   const normalizedTargetDate = normalizeDateValue(targetDate);
-  const normalizedStartDate = normalizeDateValue(task.date ?? task.dateKey);
+  const normalizedStartDate = normalizeDateValue(task.dateKey ?? task.date);
 
   if (!normalizedTargetDate || !normalizedStartDate) {
     return false;


### PR DESCRIPTION
### Motivation
- Fix a transient visual bug where a newly created task briefly appears on the current day even when scheduled for a different date.
- Ensure the scheduling/visibility logic uses the canonical, normalized task date value when available to avoid mismatches.

### Description
- Change in `utils/dateUtils.js`: `shouldTaskAppearOnDate` now prefers `task.dateKey` over `task.date` when determining the task start date by using `normalizeDateValue(task.dateKey ?? task.date)`.
- This small ordering change makes task appearance decisions rely on the stored normalized key when present, reducing momentary inconsistencies after task creation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603b163f788326967f7ec317ecfbad)