### PR TITLE
Add confetti celebration and prefer `task.dateKey` when scheduling tasks

### DIFF
--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -109,7 +109,7 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
   }
 
   const normalizedTargetDate = normalizeDateValue(targetDate);
-  const normalizedStartDate = normalizeDateValue(task.date ?? task.dateKey);
+  const normalizedStartDate = normalizeDateValue(task.dateKey ?? task.date);
 
   if (!normalizedTargetDate || !normalizedStartDate) {
     return false;


### PR DESCRIPTION
### Motivation
- Fix a transient scheduling/visibility mismatch by preferring the canonical normalized task key when available (`task.dateKey`).
- Add a celebratory confetti effect that appears when all tasks for the selected day are completed, per feature request.
- Ensure the celebration triggers only on the transition to all-complete and resets when switching days.

### Description
- Updated `shouldTaskAppearOnDate` to prefer `task.dateKey` when computing the normalized start date (`normalizeDateValue(task.dateKey ?? task.date)`).
- Added a `ConfettiOverlay` component in `App.js` and constants `CONFETTI_COLORS`, `CONFETTI_COUNT`, and `CONFETTI_DURATION_MS` that animate confetti pieces using `Animated.timing` and `Animated.stagger`.
- Integrated the overlay into the main app by adding `showConfetti`, `confettiKey`, and `previousCompletionRef` state/refs and `useEffect` hooks to trigger/clear the celebration when `allTasksCompletedForSelectedDay` changes and when `selectedDateKey` changes.
- Added styles `confettiContainer` and `confettiPiece` and rendered `<ConfettiOverlay />` above the app frame.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603b163f788326967f7ec317ecfbad)