### PR TITLE
Refine confetti animation, add success audio/haptics, and prefer `task.dateKey` for scheduling

### DIFF
--- a/App.js
+++ b/App.js
@@ -27,6 +27,7 @@ import { SafeAreaProvider, SafeAreaView, useSafeAreaInsets } from 'react-native-
 import { LinearGradient } from 'expo-linear-gradient';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import * as Haptics from 'expo-haptics';
+import { Audio } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import * as FileSystem from 'expo-file-system/legacy';
 import {
@@ -105,6 +106,9 @@ const USE_NATIVE_DRIVER = Platform.OS !== 'web';
 const HAPTICS_SUPPORTED = Platform.OS === 'ios' || Platform.OS === 'android';
 const FALLBACK_EMOJI = '📝';
 const DEFAULT_REPEAT_CONFIG = { enabled: true, frequency: 'daily', interval: 1 };
+const CONFETTI_COLORS = ['#ff6b6b', '#ffd93d', '#6bcB77', '#4d96ff', '#845ec2'];
+const CONFETTI_COUNT = 32;
+const CONFETTI_DURATION_MS = 2400;
 
 const normalizeRepeatConfig = (repeatConfig) => {
   if (!repeatConfig) {
@@ -146,6 +150,137 @@ const triggerSelection = () => {
   } catch (error) {
     // Ignore web environments without haptics support
   }
+};
+
+const triggerSuccessFeedback = async () => {
+  if (HAPTICS_SUPPORTED) {
+    try {
+      await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } catch (error) {
+      console.log('Unable to trigger success haptics', error);
+    }
+  }
+
+  try {
+    const { sound } = await Audio.Sound.createAsync(
+      { uri: 'https://www.soundjay.com/misc/sounds/bell-ringing-05.mp3' },
+      { shouldPlay: true }
+    );
+
+    sound.setOnPlaybackStatusUpdate((status) => {
+      if (status.isLoaded && status.didJustFinish) {
+        void sound.unloadAsync();
+      }
+    });
+  } catch (error) {
+    console.log('Unable to play success sound', error);
+  }
+};
+
+const ConfettiOverlay = ({ visible, onComplete }) => {
+  const { width, height } = useWindowDimensions();
+  const pieces = useMemo(
+    () =>
+      Array.from({ length: CONFETTI_COUNT }, (_, index) => ({
+        id: `${Date.now()}-${index}`,
+        baseX: new Animated.Value(Math.random() * width),
+        size: 6 + Math.random() * 6,
+        delay: Math.random() * 400,
+        rotate: Math.random() * 120,
+        heightRatio: Math.random() > 0.5 ? 1.5 : 0.8,
+        rotationTurns: 360 * (Math.random() * 4 + 1),
+        swayAmplitude: 12 + Math.random() * 18,
+        swayDuration: 800 + Math.random() * 900,
+        color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+        anim: new Animated.Value(-20 - Math.random() * 120),
+        swayAnim: new Animated.Value(0),
+        scaleAnim: new Animated.Value(Math.random() * 0.5 + 0.5),
+        duration: CONFETTI_DURATION_MS + Math.random() * 1000,
+      })),
+    [width]
+  );
+
+  useEffect(() => {
+    if (!visible) {
+      return undefined;
+    }
+
+    const animations = pieces.map((piece) =>
+      Animated.timing(piece.anim, {
+        toValue: height + 100,
+        duration: piece.duration,
+        delay: piece.delay,
+        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+        useNativeDriver: true,
+      })
+    );
+    const swayLoops = pieces.map((piece) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(piece.swayAnim, {
+            toValue: piece.swayAmplitude,
+            duration: piece.swayDuration,
+            easing: Easing.inOut(Easing.sin),
+            useNativeDriver: true,
+          }),
+          Animated.timing(piece.swayAnim, {
+            toValue: -piece.swayAmplitude,
+            duration: piece.swayDuration,
+            easing: Easing.inOut(Easing.sin),
+            useNativeDriver: true,
+          }),
+        ])
+      )
+    );
+
+    const animation = Animated.stagger(40, animations);
+    animation.start();
+    swayLoops.forEach((loop) => loop.start());
+
+    const timeoutId = setTimeout(() => {
+      onComplete?.();
+    }, CONFETTI_DURATION_MS + 1500);
+
+    return () => {
+      animation.stop();
+      swayLoops.forEach((loop) => loop.stop());
+      clearTimeout(timeoutId);
+    };
+  }, [height, onComplete, pieces, visible]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <View pointerEvents="none" style={styles.confettiContainer}>
+      {pieces.map((piece) => (
+        <Animated.View
+          key={piece.id}
+          style={[
+            styles.confettiPiece,
+            {
+              width: piece.size,
+              height: piece.size * piece.heightRatio,
+              backgroundColor: piece.color,
+              opacity: 0.8,
+              transform: [
+                { translateX: Animated.add(piece.baseX, piece.swayAnim) },
+                { translateY: piece.anim },
+                {
+                  rotate: piece.anim.interpolate({
+                    inputRange: [0, height],
+                    outputRange: ['0deg', `${piece.rotationTurns}deg`],
+                  }),
+                },
+                { scale: piece.scaleAnim },
+              ],
+            },
+          ]}
+        />
+      ))}
+    </View>
+  );
 };
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -884,6 +1019,22 @@ function ScheduleApp() {
     () => tasksForSelectedDate.filter((task) => getTaskCompletionStatus(task, selectedDateKey)).length,
     [selectedDateKey, tasksForSelectedDate]
   );
+  const [showConfetti, setShowConfetti] = useState(false);
+  const [confettiKey, setConfettiKey] = useState(0);
+  const previousCompletionRef = useRef(false);
+
+  useEffect(() => {
+    if (allTasksCompletedForSelectedDay && !previousCompletionRef.current) {
+      setConfettiKey((previous) => previous + 1);
+      setShowConfetti(true);
+      void triggerSuccessFeedback();
+    }
+    previousCompletionRef.current = allTasksCompletedForSelectedDay;
+  }, [allTasksCompletedForSelectedDay]);
+
+  useEffect(() => {
+    previousCompletionRef.current = false;
+  }, [selectedDateKey]);
   const activeTask = useMemo(
     () => tasks.find((task) => task.id === activeTaskId) ?? null,
     [activeTaskId, tasks]
@@ -1877,6 +2028,12 @@ function ScheduleApp() {
         barStyle="dark-content"
         backgroundColor="#f6f6fb"
         translucent={false}
+      />
+
+      <ConfettiOverlay
+        key={confettiKey}
+        visible={showConfetti}
+        onComplete={() => setShowConfetti(false)}
       />
 
       <View style={styles.container}>
@@ -3838,6 +3995,20 @@ const styles = StyleSheet.create({
   appFrame: {
     flex: 1,
     backgroundColor: '#f6f6fb',
+  },
+  confettiContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 20,
+    elevation: 10,
+  },
+  confettiPiece: {
+    position: 'absolute',
+    borderRadius: 2,
+    opacity: 0.9,
   },
   content: {
     flex: 1,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/vector-icons": "^15.0.3",
         "date-fns": "^4.1.0",
         "expo": "^54.0.25",
+        "expo-av": "^16.0.8",
         "expo-file-system": "^16.0.5",
         "expo-haptics": "^15.0.7",
         "expo-image-picker": "^15.0.7",
@@ -4144,6 +4145,23 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-16.0.8.tgz",
+      "integrity": "sha512-cmVPftGR/ca7XBgs7R6ky36lF3OC0/MM/lpgX/yXqfv0jASTsh7AYX9JxHCwFmF+Z6JEB1vne9FDx4GiLcGreQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@expo/vector-icons": "^15.0.3",
     "date-fns": "^4.1.0",
     "expo": "^54.0.25",
+    "expo-av": "^16.0.8",
     "expo-file-system": "^16.0.5",
     "expo-haptics": "^15.0.7",
     "expo-image-picker": "^15.0.7",

--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -109,7 +109,7 @@ const shouldTaskAppearOnDate = (task, targetDate) => {
   }
 
   const normalizedTargetDate = normalizeDateValue(targetDate);
-  const normalizedStartDate = normalizeDateValue(task.date ?? task.dateKey);
+  const normalizedStartDate = normalizeDateValue(task.dateKey ?? task.date);
 
   if (!normalizedTargetDate || !normalizedStartDate) {
     return false;


### PR DESCRIPTION
### Motivation
- Prevent UI jank and occasional freezes by offloading confetti animations to the native driver and refining particle physics for a smoother visual effect.  
- Improve user feedback when a day’s tasks are completed by adding haptic and audio success cues.  
- Make scheduling/visibility calculation more robust by preferring the canonical normalized task key when available (`task.dateKey`).  
- Keep the celebration tied to the transition to all-complete and reset it when switching days.

### Description
- Updated `shouldTaskAppearOnDate` to prefer `task.dateKey` over `task.date` when computing the normalized start date.  
- Added a `ConfettiOverlay` component with native-driven animations (`useNativeDriver: true`), `Easing.bezier` easing, staggered fall timings, lateral sway (`swayAnim`), per-piece `scaleAnim`, and rotation interpolated from vertical position, plus cleanup logic.  
- Integrated confetti triggering into `ScheduleApp` via `showConfetti`, `confettiKey`, and `previousCompletionRef`, and added `triggerSuccessFeedback` which uses `expo-haptics` and `expo-av` to emit a success vibration and play a short sound.  
- Added constants and styles (`CONFETTI_COLORS`, `CONFETTI_COUNT`, `CONFETTI_DURATION_MS`, `confettiContainer`, `confettiPiece`) and updated `package.json`/`package-lock.json` to include the `expo-av` dependency.

### Testing
- No automated tests were run for these changes.  
- (Manual verification recommended on device/emulator to validate `expo-av` playback and `expo-haptics` behavior under native runtime.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603b163f788326967f7ec317ecfbad)