### PR TITLE
Persist custom tag options from existing tasks

### DIFF
--- a/App.js
+++ b/App.js
@@ -944,6 +944,21 @@ function ScheduleApp() {
     };
     return filtered.slice().sort((a, b) => getSortValue(a) - getSortValue(b));
   }, [selectedDate, tasks]);
+  const availableTagOptions = useMemo(() => {
+    const seen = new Set();
+    return tasks.reduce((options, task) => {
+      const key = normalizeTaskTagKey(task);
+      if (!key || seen.has(key)) {
+        return options;
+      }
+      seen.add(key);
+      options.push({
+        key,
+        label: getTaskTagDisplayLabel(task) ?? 'Tag',
+      });
+      return options;
+    }, []);
+  }, [tasks]);
   const tagOptions = useMemo(() => {
     const seen = new Set();
     return tasksForSelectedDate.reduce((options, task) => {
@@ -960,11 +975,15 @@ function ScheduleApp() {
     }, []);
   }, [tasksForSelectedDate]);
   useEffect(() => {
-    if (selectedTagFilter !== 'all' && !tagOptions.some((option) => option.key === selectedTagFilter)) {
+    if (
+      selectedTagFilter !== 'all' &&
+      availableTagOptions.length > 0 &&
+      !availableTagOptions.some((option) => option.key === selectedTagFilter)
+    ) {
       setSelectedTagFilter('all');
       updateUserSettings({ selectedTagFilter: 'all' });
     }
-  }, [selectedTagFilter, tagOptions, updateUserSettings]);
+  }, [availableTagOptions, selectedTagFilter, updateUserSettings]);
   const visibleTasks = useMemo(() => {
     if (selectedTagFilter === 'all') {
       return tasksForSelectedDate;
@@ -2638,6 +2657,7 @@ function ScheduleApp() {
         }}
         mode={habitSheetMode}
         initialHabit={habitSheetInitialTask}
+        availableTagOptions={availableTagOptions}
       />
       <QuantumAdjustModal
         task={tasks.find((task) => task.id === quantumAdjustTaskId) ?? null}


### PR DESCRIPTION
### Motivation
- Make custom tags created on tasks available system-wide so other tasks can reuse them while at least one task references the tag.
- Keep built-in default tags always present even if no tasks are using them.

### Description
- Add `availableTagOptions` in `App.js` derived from all `tasks` and pass it into `AddHabitSheet` via the `availableTagOptions` prop.
- Update tag filter reset logic to consult `availableTagOptions` before forcing `selectedTagFilter` back to `all` so user filters are preserved when appropriate.
- Extend `AddHabitSheet` to accept `availableTagOptions`, introduce a `mergeTagOptions` helper, and merge task-derived tags with `DEFAULT_TAG_OPTIONS` when opening and resetting the sheet so custom tags persist while they are in use.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604b93513483268d0f2b53edd2f50e)