### PR TITLE
Update quantum timer labels to hours/minutes

### DIFF
--- a/App.js
+++ b/App.js
@@ -3861,7 +3861,7 @@ function QuantumAdjustModal({
           {isTimer ? (
             <View style={styles.quantumModalRow}>
               <View style={styles.quantumModalField}>
-                <Text style={styles.quantumModalFieldLabel}>Min</Text>
+                <Text style={styles.quantumModalFieldLabel}>Hour</Text>
                 <TextInput
                   style={styles.quantumModalInput}
                   value={minutesValue}
@@ -3873,7 +3873,7 @@ function QuantumAdjustModal({
                 />
               </View>
               <View style={styles.quantumModalField}>
-                <Text style={styles.quantumModalFieldLabel}>Sec</Text>
+                <Text style={styles.quantumModalFieldLabel}>Min</Text>
                 <TextInput
                   style={styles.quantumModalInput}
                   value={secondsValue}

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -2152,7 +2152,7 @@ function QuantumPanel({
         {isTimer ? (
           <View style={styles.quantumTimerRow}>
             <View style={styles.quantumField}>
-              <Text style={styles.quantumFieldLabel}>Min</Text>
+              <Text style={styles.quantumFieldLabel}>Hour</Text>
               <TextInput
                 style={styles.quantumFieldInput}
                 value={timerMinutes}
@@ -2161,11 +2161,11 @@ function QuantumPanel({
                 maxLength={2}
                 placeholder="00"
                 placeholderTextColor="#9AA5B5"
-                accessibilityLabel="Timer minutes"
+                accessibilityLabel="Timer hours"
               />
             </View>
             <View style={styles.quantumField}>
-              <Text style={styles.quantumFieldLabel}>Sec</Text>
+              <Text style={styles.quantumFieldLabel}>Min</Text>
               <TextInput
                 style={styles.quantumFieldInput}
                 value={timerSeconds}
@@ -2174,7 +2174,7 @@ function QuantumPanel({
                 maxLength={2}
                 placeholder="00"
                 placeholderTextColor="#9AA5B5"
-                accessibilityLabel="Timer seconds"
+                accessibilityLabel="Timer minutes"
               />
             </View>
           </View>
@@ -2239,7 +2239,7 @@ function QuantumPanel({
       </View>
       <Text style={styles.subtasksPanelHint}>
         {isTimer
-          ? 'Set the timer duration in minutes and seconds.'
+          ? 'Set the timer duration in hours and minutes.'
           : 'Set the count and the unit for this habit.'}
       </Text>
     </View>


### PR DESCRIPTION
### Motivation
- The quantum timer UI previously showed minutes/seconds which appears inconsistent with intended use of hours/minutes for longer durations.
- Improve clarity by relabeling timer inputs and helper text to reflect hours and minutes.

### Description
- Change labels in `App.js` quantum adjust modal from `Min`/`Sec` to `Hour`/`Min`.
- Update `components/AddHabitSheet.js` quantum panel labels from `Min`/`Sec` to `Hour`/`Min` and adjust the helper text to `Set the timer duration in hours and minutes.`
- Align accessibility labels for the timer inputs to `Timer hours` and `Timer minutes`.

### Testing
- No automated tests were run for this change.
- Files modified: `App.js` and `components/AddHabitSheet.js` and changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604f4301a08326b9b0d7f927c9e4f7)