### PR TITLE
Refine time picker wheel and enhance quantum timer modal

### DIFF
--- a/App.js
+++ b/App.js
@@ -3797,8 +3797,13 @@ function QuantumAdjustModal({
   const isTimer = task?.quantum?.mode === 'timer';
   const limitLabel = task ? getQuantumProgressLabel(task, dateKey) : null;
   const limitCount = task?.quantum?.count?.value ?? 0;
+  const maxTimerMinutes = task?.quantum?.timer?.minutes ?? 0;
+  const maxTimerSeconds = task?.quantum?.timer?.seconds ?? 0;
+  const maxTimerTotalSeconds = maxTimerMinutes * 60 + maxTimerSeconds;
   const lastAdjustCount = task?.quantum?.lastAdjustCount ?? null;
   const normalizedCountValue = Number.parseInt(countValue, 10) || 0;
+  const normalizedMinutesValue = Number.parseInt(minutesValue, 10) || 0;
+  const normalizedSecondsValue = Number.parseInt(secondsValue, 10) || 0;
   const lastCountValue = lastAdjustCount ?? Math.max(1, normalizedCountValue || 1);
   const halfCountValue = limitCount ? Math.max(1, Math.round(limitCount / 2)) : 0;
   const maxCountValue = limitCount ?? 0;
@@ -3828,6 +3833,16 @@ function QuantumAdjustModal({
       onChangeCount(String(value));
     },
     [onChangeCount]
+  );
+  const handleTimerPresetSelect = useCallback(
+    (minutes, seconds) => {
+      if (minutes == null || seconds == null) {
+        return;
+      }
+      onChangeMinutes(String(minutes));
+      onChangeSeconds(String(seconds));
+    },
+    [onChangeMinutes, onChangeSeconds]
   );
   const disableActions = isTimer
     ? (Number.parseInt(minutesValue, 10) || 0) * 60 + (Number.parseInt(secondsValue, 10) || 0) <= 0
@@ -3859,32 +3874,105 @@ function QuantumAdjustModal({
             <Text style={styles.quantumModalSubtitle}>Current: {limitLabel}</Text>
           )}
           {isTimer ? (
-            <View style={styles.quantumModalRow}>
-              <View style={styles.quantumModalField}>
-                <Text style={styles.quantumModalFieldLabel}>Hour</Text>
-                <TextInput
-                  style={styles.quantumModalInput}
-                  value={minutesValue}
-                  onChangeText={handleMinutesChange}
-                  keyboardType="number-pad"
-                  maxLength={2}
-                  placeholder="0"
-                  placeholderTextColor="#9AA5B5"
-                />
+            <>
+              <View style={styles.quantumModalPresetRow}>
+                <Pressable
+                  style={[
+                    styles.quantumModalPresetButton,
+                    normalizedMinutesValue === 0 &&
+                      normalizedSecondsValue === 30 &&
+                      styles.quantumModalPresetButtonSelected,
+                  ]}
+                  onPress={() => handleTimerPresetSelect(0, 30)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Use 30 minutes"
+                >
+                  <Text
+                    style={[
+                      styles.quantumModalPresetText,
+                      normalizedMinutesValue === 0 &&
+                        normalizedSecondsValue === 30 &&
+                        styles.quantumModalPresetTextSelected,
+                    ]}
+                  >
+                    30 min
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={[
+                    styles.quantumModalPresetButton,
+                    normalizedMinutesValue === 1 &&
+                      normalizedSecondsValue === 0 &&
+                      styles.quantumModalPresetButtonSelected,
+                  ]}
+                  onPress={() => handleTimerPresetSelect(1, 0)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Use 1 hour"
+                >
+                  <Text
+                    style={[
+                      styles.quantumModalPresetText,
+                      normalizedMinutesValue === 1 &&
+                        normalizedSecondsValue === 0 &&
+                        styles.quantumModalPresetTextSelected,
+                    ]}
+                  >
+                    1 hour
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={[
+                    styles.quantumModalPresetButton,
+                    normalizedMinutesValue === maxTimerMinutes &&
+                      normalizedSecondsValue === maxTimerSeconds &&
+                      maxTimerTotalSeconds > 0 &&
+                      styles.quantumModalPresetButtonSelected,
+                  ]}
+                  onPress={() => handleTimerPresetSelect(maxTimerMinutes, maxTimerSeconds)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Use max"
+                  disabled={maxTimerTotalSeconds <= 0}
+                >
+                  <Text
+                    style={[
+                      styles.quantumModalPresetText,
+                      normalizedMinutesValue === maxTimerMinutes &&
+                        normalizedSecondsValue === maxTimerSeconds &&
+                        maxTimerTotalSeconds > 0 &&
+                        styles.quantumModalPresetTextSelected,
+                    ]}
+                  >
+                    max
+                  </Text>
+                </Pressable>
               </View>
-              <View style={styles.quantumModalField}>
-                <Text style={styles.quantumModalFieldLabel}>Min</Text>
-                <TextInput
-                  style={styles.quantumModalInput}
-                  value={secondsValue}
-                  onChangeText={handleSecondsChange}
-                  keyboardType="number-pad"
-                  maxLength={2}
-                  placeholder="0"
-                  placeholderTextColor="#9AA5B5"
-                />
+              <View style={styles.quantumModalAmount}>
+                <Text style={styles.quantumModalAmountLabel}>Amount</Text>
+                <View style={styles.quantumModalAmountInput}>
+                  <TextInput
+                    style={styles.quantumModalAmountValue}
+                    value={minutesValue}
+                    onChangeText={handleMinutesChange}
+                    keyboardType="number-pad"
+                    maxLength={2}
+                    placeholder="00"
+                    placeholderTextColor="#B4BCCB"
+                    accessibilityLabel="Timer hours"
+                  />
+                  <Text style={styles.quantumModalAmountSeparator}>:</Text>
+                  <TextInput
+                    style={styles.quantumModalAmountValue}
+                    value={secondsValue}
+                    onChangeText={handleSecondsChange}
+                    keyboardType="number-pad"
+                    maxLength={2}
+                    placeholder="00"
+                    placeholderTextColor="#B4BCCB"
+                    accessibilityLabel="Timer minutes"
+                  />
+                </View>
               </View>
-            </View>
+            </>
           ) : (
             <>
               <View style={styles.quantumModalPresetRow}>
@@ -4447,12 +4535,12 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 360,
     backgroundColor: '#FFFFFF',
-    borderRadius: 24,
-    padding: 20,
+    borderRadius: 26,
+    padding: 22,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.1,
-    shadowRadius: 16,
+    shadowOpacity: 0.12,
+    shadowRadius: 18,
     elevation: 8,
   },
   quantumModalHeader: {
@@ -4461,12 +4549,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   quantumModalTitle: {
-    fontSize: 18,
+    fontSize: 20,
     fontWeight: '700',
     color: '#1F2742',
   },
   quantumModalSubtitle: {
-    marginTop: 8,
+    marginTop: 6,
     fontSize: 14,
     color: '#7F8A9A',
   },
@@ -4477,19 +4565,22 @@ const styles = StyleSheet.create({
   },
   quantumModalPresetRow: {
     flexDirection: 'row',
-    gap: 12,
-    marginTop: 14,
+    gap: 10,
+    marginTop: 16,
   },
   quantumModalPresetButton: {
     flex: 1,
     paddingVertical: 10,
-    borderRadius: 14,
+    borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#EEF3FF',
+    backgroundColor: '#F4F6FB',
+    borderWidth: 1,
+    borderColor: '#D5DBE8',
   },
   quantumModalPresetButtonSelected: {
     backgroundColor: '#1F2742',
+    borderColor: '#1F2742',
   },
   quantumModalPresetText: {
     fontSize: 14,
@@ -4518,26 +4609,61 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: '#1F2742',
   },
+  quantumModalAmount: {
+    marginTop: 16,
+  },
+  quantumModalAmountLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#7F8A9A',
+    marginBottom: 8,
+  },
+  quantumModalAmountInput: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: '#D5DBE8',
+    backgroundColor: '#F8FAFF',
+  },
+  quantumModalAmountValue: {
+    minWidth: 64,
+    textAlign: 'center',
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#1F2742',
+  },
+  quantumModalAmountSeparator: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#1F2742',
+  },
   quantumModalActions: {
     flexDirection: 'row',
     gap: 12,
-    marginTop: 20,
+    marginTop: 22,
   },
   quantumModalButton: {
     flex: 1,
-    paddingVertical: 12,
-    borderRadius: 14,
+    paddingVertical: 14,
+    borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: '#D5DBE8',
   },
   quantumModalButtonAdd: {
     backgroundColor: '#1F2742',
+    borderColor: '#1F2742',
   },
   quantumModalButtonSubtract: {
-    backgroundColor: '#EEF3FF',
+    backgroundColor: '#F4F6FB',
   },
   quantumModalButtonText: {
-    fontSize: 18,
+    fontSize: 22,
     fontWeight: '700',
     color: '#1F2742',
   },

--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -2805,9 +2805,6 @@ function TimePanel({
                     onSelect={(value) => onPointTimeChange({ ...pointTime, hour: value })}
                     formatter={(value) => formatNumber(value)}
                   />
-                  <Text pointerEvents="none" style={styles.wheelDivider}>
-                    :
-                  </Text>
                   <WheelColumn
                     values={MINUTE_VALUES}
                     selectedIndex={minuteIndex}
@@ -2844,9 +2841,6 @@ function TimePanel({
                       }
                       formatter={(value) => formatNumber(value)}
                     />
-                    <Text pointerEvents="none" style={styles.wheelDivider}>
-                      :
-                    </Text>
                     <WheelColumn
                       values={MINUTE_VALUES}
                       selectedIndex={startMinuteIndex}
@@ -2889,9 +2883,6 @@ function TimePanel({
                       }
                       formatter={(value) => formatNumber(value)}
                     />
-                    <Text pointerEvents="none" style={styles.wheelDivider}>
-                      :
-                    </Text>
                     <WheelColumn
                       values={MINUTE_VALUES}
                       selectedIndex={endMinuteIndex}
@@ -2949,6 +2940,8 @@ function WheelColumn({
   const scrollRef = useRef(null);
   const isMomentumScrolling = useRef(false);
   const isDragging = useRef(false);
+  const [displayIndex, setDisplayIndex] = useState(selectedIndex);
+  const lastHapticIndex = useRef(selectedIndex);
 
   useEffect(() => {
     if (!scrollRef.current || isMomentumScrolling.current || isDragging.current) {
@@ -2959,6 +2952,11 @@ function WheelColumn({
     });
     return () => cancelAnimationFrame(frame);
   }, [selectedIndex, itemHeight]);
+
+  useEffect(() => {
+    setDisplayIndex(selectedIndex);
+    lastHapticIndex.current = selectedIndex;
+  }, [selectedIndex]);
 
   const finalizeSelection = useCallback(
     (offsetY) => {
@@ -2979,6 +2977,32 @@ function WheelColumn({
       }
     },
     [itemHeight, values, onSelect, selectedIndex]
+  );
+
+  const handleScroll = useCallback(
+    (event) => {
+      const offsetY = event.nativeEvent.contentOffset.y ?? 0;
+      const maxOffset = Math.max(0, (values.length - 1) * itemHeight);
+      const clampedOffset = Math.min(Math.max(offsetY, 0), maxOffset);
+      const index = Math.round(clampedOffset / itemHeight);
+      const clampedIndex = Math.min(Math.max(index, 0), values.length - 1);
+
+      if (clampedIndex !== displayIndex) {
+        setDisplayIndex(clampedIndex);
+      }
+
+      if (clampedIndex !== lastHapticIndex.current) {
+        lastHapticIndex.current = clampedIndex;
+        if (HAPTICS_SUPPORTED && typeof Haptics.selectionAsync === 'function') {
+          try {
+            Haptics.selectionAsync();
+          } catch (error) {
+            // Ignore missing haptics support on web
+          }
+        }
+      }
+    },
+    [displayIndex, itemHeight, values.length]
   );
 
   const handleMomentumBegin = useCallback(() => {
@@ -3018,7 +3042,7 @@ function WheelColumn({
       showsVerticalScrollIndicator={false}
       // deixa o sistema cuidar do momentum e nós só "arredondamos" no fim:
       snapToInterval={itemHeight}
-      decelerationRate={Platform.select({ ios: 'fast', android: 0.998 })}
+      decelerationRate="fast"
       overScrollMode="never"
       bounces
       scrollEventThrottle={16}
@@ -3026,13 +3050,14 @@ function WheelColumn({
       // evita que o gesto suba para o pan da folha:
       onStartShouldSetResponderCapture={() => true}
       onMoveShouldSetResponderCapture={() => true}
+      onScroll={handleScroll}
       onMomentumScrollBegin={handleMomentumBegin}
       onMomentumScrollEnd={handleMomentumEnd}
       onScrollBeginDrag={handleScrollBeginDrag}
       onScrollEndDrag={handleScrollEndDrag}
     >
       {values.map((value, index) => {
-        const isActive = index === selectedIndex;
+        const isActive = index === displayIndex;
         return (
           <View key={`${value}-${index}`} style={[styles.wheelItem, { height: itemHeight }]}>
             <Text style={[styles.wheelItemText, isActive && styles.wheelItemTextActive]}>
@@ -3969,13 +3994,6 @@ const styles = StyleSheet.create({
     letterSpacing: 0.6,
     color: '#7F8A9A',
     textTransform: 'uppercase',
-  },
-  wheelDivider: {
-    alignSelf: 'center',
-    fontSize: 26,
-    fontWeight: '700',
-    color: '#1F2742',
-    marginHorizontal: 2,
   },
   periodSection: {
     marginTop: 6,


### PR DESCRIPTION
### Motivation
- Make the time selector compact and smooth with a three-column wheel (Hour / Min / AM/PM) showing ~5 items and a centered selection highlight. 
- Provide a better tactile and visual scrolling experience so values snap cleanly into place and give haptic feedback while scrolling. 
- Make the quantum/timer adjust modal faster to use by adding common presets and a combined HH:MM amount input. 
- Surface task-configured timer limits so a `max` preset can be offered and visually selected.

### Description
- Updated the time wheel in `components/AddHabitSheet.js` to remove the colon divider, render three side-by-side `WheelColumn` components, and use a fixed window height of `WHEEL_ITEM_HEIGHT * 5` with the existing center highlight. 
- Implemented live scroll handling in the wheel via a `displayIndex` state, an `onScroll` handler that snap-computes the nearest index, and calls `Haptics.selectionAsync()` when the central value changes. 
- Kept final selection logic with `finalizeSelection` on momentum/drag end and set `snapToInterval={itemHeight}` and `decelerationRate="fast"` to produce smooth snap behaviour. 
- Enhanced the quantum adjust modal in `App.js` to add timer preset buttons (`30 min`, `1 hour`, `max`), a `handleTimerPresetSelect` helper, a combined prominent `Amount` HH:MM input, and to read `task.quantum.timer` (`minutes`/`seconds`) for the `max` preset and selected state, plus related style adjustments.

### Testing
- No automated tests were executed for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696198e32260832696b3669b0101333e)