### PR TITLE
Refine timer wheel picker styling and add ScrollView-based WheelPicker

### DIFF
--- a/App.js
+++ b/App.js
@@ -15,7 +15,6 @@ import {
   StyleSheet,
   Text,
   TextInput,
-  FlatList,
   TouchableOpacity,
   View,
   useWindowDimensions,
@@ -3949,27 +3948,24 @@ function QuantumAdjustModal({
               <View style={styles.quantumModalAmount}>
                 <Text style={styles.quantumModalAmountLabel}>Amount</Text>
                 <View style={styles.quantumModalAmountInput}>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={minutesValue}
-                    onChangeText={handleMinutesChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer hours"
-                  />
-                  <Text style={styles.quantumModalAmountSeparator}>:</Text>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={secondsValue}
-                    onChangeText={handleSecondsChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer minutes"
-                  />
+                  <View style={styles.timerWheelArea}>
+                    <View pointerEvents="none" style={styles.timerWheelHighlight} />
+                    <View style={styles.timerWheelRow}>
+                      <WheelPicker
+                        values={TIMER_HOUR_OPTIONS}
+                        value={normalizeTimerValue(minutesValue, TIMER_HOUR_OPTIONS)}
+                        onChange={handleMinutesChange}
+                        accessibilityLabel="Timer hours"
+                      />
+                      <Text style={styles.timerWheelDivider}>:</Text>
+                      <WheelPicker
+                        values={TIMER_MINUTE_OPTIONS}
+                        value={normalizeTimerValue(secondsValue, TIMER_MINUTE_OPTIONS)}
+                        onChange={handleSecondsChange}
+                        accessibilityLabel="Timer minutes"
+                      />
+                    </View>
+                  </View>
                 </View>
               </View>
             </>
@@ -4074,6 +4070,127 @@ function QuantumAdjustModal({
         </View>
       </View>
     </Modal>
+  );
+}
+
+const WHEEL_ITEM_HEIGHT = 34;
+const WHEEL_VISIBLE_ITEMS = 3;
+
+const TIMER_HOUR_OPTIONS = Array.from({ length: 100 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+const TIMER_MINUTE_OPTIONS = Array.from({ length: 60 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+
+function normalizeTimerValue(value, options) {
+  const sanitized = value?.replace(/\D/g, '') ?? '';
+  if (!sanitized) {
+    return options[0];
+  }
+  const normalized = Number.parseInt(sanitized, 10);
+  if (Number.isNaN(normalized)) {
+    return options[0];
+  }
+  const clamped = Math.min(Math.max(normalized, 0), options.length - 1);
+  return options[clamped];
+}
+
+function WheelPicker({ values, value, onChange, accessibilityLabel, itemHeight = WHEEL_ITEM_HEIGHT }) {
+  const scrollRef = useRef(null);
+  const isMomentumScrolling = useRef(false);
+  const isDragging = useRef(false);
+  const valueIndex = Math.max(0, values.indexOf(value));
+
+  useEffect(() => {
+    if (!scrollRef.current || isMomentumScrolling.current || isDragging.current) {
+      return undefined;
+    }
+    const frame = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ y: valueIndex * itemHeight, animated: false });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [valueIndex, itemHeight]);
+
+  const finalizeSelection = useCallback(
+    (offsetY) => {
+      const maxOffset = Math.max(0, (values.length - 1) * itemHeight);
+      const clampedOffset = Math.min(Math.max(offsetY, 0), maxOffset);
+      const index = Math.round(clampedOffset / itemHeight);
+      const clampedIndex = Math.min(Math.max(index, 0), values.length - 1);
+      const nextValue = values[clampedIndex];
+
+      if (nextValue && clampedIndex !== valueIndex) {
+        onChange(nextValue);
+        if (HAPTICS_SUPPORTED && typeof Haptics.selectionAsync === 'function') {
+          try {
+            Haptics.selectionAsync();
+          } catch {
+            // Ignore missing haptics support on web
+          }
+        }
+      }
+    },
+    [itemHeight, onChange, valueIndex, values]
+  );
+
+  const handleMomentumBegin = useCallback(() => {
+    isMomentumScrolling.current = true;
+  }, []);
+
+  const handleMomentumEnd = useCallback(
+    (event) => {
+      isMomentumScrolling.current = false;
+      finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+    },
+    [finalizeSelection]
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    isDragging.current = true;
+  }, []);
+
+  const handleScrollEndDrag = useCallback(
+    (event) => {
+      isDragging.current = false;
+      if (!isMomentumScrolling.current) {
+        finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+      }
+    },
+    [finalizeSelection]
+  );
+
+  return (
+    <ScrollView
+      ref={scrollRef}
+      style={styles.timerWheelColumn}
+      contentContainerStyle={[styles.timerWheelColumnContent, { paddingVertical: itemHeight }]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={itemHeight}
+      decelerationRate={Platform.select({ ios: 'fast', android: 0.998 })}
+      overScrollMode="never"
+      bounces
+      scrollEventThrottle={16}
+      nestedScrollEnabled
+      onStartShouldSetResponderCapture={() => true}
+      onMoveShouldSetResponderCapture={() => true}
+      onMomentumScrollBegin={handleMomentumBegin}
+      onMomentumScrollEnd={handleMomentumEnd}
+      onScrollBeginDrag={handleScrollBeginDrag}
+      onScrollEndDrag={handleScrollEndDrag}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {values.map((item, index) => {
+        const isActive = index === valueIndex;
+        return (
+          <View key={`${item}-${index}`} style={[styles.timerWheelItem, { height: itemHeight }]}>
+            <Text style={[styles.timerWheelItemText, isActive && styles.timerWheelItemTextActive]}>
+              {item}
+            </Text>
+          </View>
+        );
+      })}
+    </ScrollView>
   );
 }
 
@@ -4619,25 +4736,64 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   quantumModalAmountInput: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 10,
+    paddingVertical: 6,
     borderRadius: 18,
     borderWidth: 1,
     borderColor: '#D5DBE8',
     backgroundColor: '#F8FAFF',
   },
-  quantumModalAmountValue: {
-    minWidth: 64,
-    textAlign: 'center',
-    fontSize: 28,
+  timerWheelArea: {
+    position: 'relative',
+    height: WHEEL_ITEM_HEIGHT * WHEEL_VISIBLE_ITEMS,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  timerWheelHighlight: {
+    position: 'absolute',
+    left: 12,
+    right: 12,
+    top: WHEEL_ITEM_HEIGHT,
+    height: WHEEL_ITEM_HEIGHT,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: 'rgba(31,39,66,0.16)',
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#1F2742',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  timerWheelRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    gap: 12,
+  },
+  timerWheelDivider: {
+    alignSelf: 'center',
+    fontSize: 18,
     fontWeight: '700',
     color: '#1F2742',
   },
-  quantumModalAmountSeparator: {
-    fontSize: 26,
+  timerWheelColumn: {
+    width: 68,
+  },
+  timerWheelColumnContent: {
+    paddingVertical: WHEEL_ITEM_HEIGHT,
+  },
+  timerWheelItem: {
+    height: WHEEL_ITEM_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timerWheelItemText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#A3AEC1',
+  },
+  timerWheelItemTextActive: {
+    fontSize: 22,
     fontWeight: '700',
     color: '#1F2742',
   },


### PR DESCRIPTION
### Motivation
- Replace fragile numeric `TextInput` timer fields with a wheel-style picker to match the existing specified-time picker UX.
- Improve touch ergonomics, selection feedback, and visual consistency for the compact timer modal.
- Adjust sizing and typography so the timer picker aligns with the app's established wheel aesthetics.

### Description
- Replaced the minutes/seconds `TextInput` controls with a `WheelPicker` built on `ScrollView` that uses `snapToInterval` and a highlight frame for selection.
- Added `WHEEL_ITEM_HEIGHT`, `WHEEL_VISIBLE_ITEMS`, `TIMER_HOUR_OPTIONS`, `TIMER_MINUTE_OPTIONS`, and `normalizeTimerValue` to support the wheel picker logic.
- Implemented `WheelPicker` which finalizes selection on scroll end and triggers haptics when available, and added corresponding styles (`timerWheel*`) and layout tweaks (padding, border radius, spacing, font sizes, column width).
- Removed the unused `FlatList` import and updated the modal layout to render the new wheel UI (divider `:` and two `WheelPicker` columns).

### Testing
- No automated tests were run for this change in the current environment.
- No CI/build validation was performed as part of this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ab44e44832685e0f41447429a75)