### PR TITLE
Increase timer wheel highlight size and add WheelPicker layout refinements

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@ import {
   Easing,
   Platform,
   Image,
+  FlatList,
   Modal,
   PanResponder,
   Pressable,
@@ -15,7 +16,6 @@ import {
   StyleSheet,
   Text,
   TextInput,
-  FlatList,
   TouchableOpacity,
   View,
   useWindowDimensions,
@@ -2816,7 +2816,7 @@ function SwipeableTaskCard({
       return null;
     }
     return `${completedSubtasks}/${totalSubtasks}`;
-  }, [completedSubtasks, task, totalSubtasks]);
+  }, [completedSubtasks, dateKey, task, totalSubtasks]);
 
   const isQuantum = task.type === 'quantum';
   const isWaterAnimation = task.quantum?.animation === 'water';
@@ -3949,27 +3949,28 @@ function QuantumAdjustModal({
               <View style={styles.quantumModalAmount}>
                 <Text style={styles.quantumModalAmountLabel}>Amount</Text>
                 <View style={styles.quantumModalAmountInput}>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={minutesValue}
-                    onChangeText={handleMinutesChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer hours"
-                  />
-                  <Text style={styles.quantumModalAmountSeparator}>:</Text>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={secondsValue}
-                    onChangeText={handleSecondsChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer minutes"
-                  />
+                  <View style={styles.timerWheelArea}>
+                    <View pointerEvents="none" style={styles.timerWheelHighlight} />
+                    <View style={styles.timerWheelRow}>
+                      <View style={styles.timerWheelColumnWrapper}>
+                        <WheelPicker
+                          values={TIMER_HOUR_OPTIONS}
+                          value={normalizeTimerValue(minutesValue, TIMER_HOUR_OPTIONS)}
+                          onChange={handleMinutesChange}
+                          accessibilityLabel="Timer hours"
+                        />
+                      </View>
+                      <Text style={styles.timerWheelDivider}>:</Text>
+                      <View style={styles.timerWheelColumnWrapper}>
+                        <WheelPicker
+                          values={TIMER_MINUTE_OPTIONS}
+                          value={normalizeTimerValue(secondsValue, TIMER_MINUTE_OPTIONS)}
+                          onChange={handleSecondsChange}
+                          accessibilityLabel="Timer minutes"
+                        />
+                      </View>
+                    </View>
+                  </View>
                 </View>
               </View>
             </>
@@ -4074,6 +4075,127 @@ function QuantumAdjustModal({
         </View>
       </View>
     </Modal>
+  );
+}
+
+const WHEEL_ITEM_HEIGHT = 34;
+const WHEEL_VISIBLE_ITEMS = 3;
+
+const TIMER_HOUR_OPTIONS = Array.from({ length: 100 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+const TIMER_MINUTE_OPTIONS = Array.from({ length: 60 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+
+function normalizeTimerValue(value, options) {
+  const sanitized = value?.replace(/\D/g, '') ?? '';
+  if (!sanitized) {
+    return options[0];
+  }
+  const normalized = Number.parseInt(sanitized, 10);
+  if (Number.isNaN(normalized)) {
+    return options[0];
+  }
+  const clamped = Math.min(Math.max(normalized, 0), options.length - 1);
+  return options[clamped];
+}
+
+function WheelPicker({ values, value, onChange, accessibilityLabel, itemHeight = WHEEL_ITEM_HEIGHT }) {
+  const scrollRef = useRef(null);
+  const isMomentumScrolling = useRef(false);
+  const isDragging = useRef(false);
+  const valueIndex = Math.max(0, values.indexOf(value));
+
+  useEffect(() => {
+    if (!scrollRef.current || isMomentumScrolling.current || isDragging.current) {
+      return undefined;
+    }
+    const frame = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ y: valueIndex * itemHeight, animated: false });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [valueIndex, itemHeight]);
+
+  const finalizeSelection = useCallback(
+    (offsetY) => {
+      const maxOffset = Math.max(0, (values.length - 1) * itemHeight);
+      const clampedOffset = Math.min(Math.max(offsetY, 0), maxOffset);
+      const index = Math.round(clampedOffset / itemHeight);
+      const clampedIndex = Math.min(Math.max(index, 0), values.length - 1);
+      const nextValue = values[clampedIndex];
+
+      if (nextValue && clampedIndex !== valueIndex) {
+        onChange(nextValue);
+        if (HAPTICS_SUPPORTED && typeof Haptics.selectionAsync === 'function') {
+          try {
+            Haptics.selectionAsync();
+          } catch {
+            // Ignore missing haptics support on web
+          }
+        }
+      }
+    },
+    [itemHeight, onChange, valueIndex, values]
+  );
+
+  const handleMomentumBegin = useCallback(() => {
+    isMomentumScrolling.current = true;
+  }, []);
+
+  const handleMomentumEnd = useCallback(
+    (event) => {
+      isMomentumScrolling.current = false;
+      finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+    },
+    [finalizeSelection]
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    isDragging.current = true;
+  }, []);
+
+  const handleScrollEndDrag = useCallback(
+    (event) => {
+      isDragging.current = false;
+      if (!isMomentumScrolling.current) {
+        finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+      }
+    },
+    [finalizeSelection]
+  );
+
+  return (
+    <ScrollView
+      ref={scrollRef}
+      style={styles.timerWheelColumn}
+      contentContainerStyle={[styles.timerWheelColumnContent, { paddingVertical: itemHeight }]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={itemHeight}
+      decelerationRate={Platform.select({ ios: 'fast', android: 0.998 })}
+      overScrollMode="never"
+      bounces
+      scrollEventThrottle={16}
+      nestedScrollEnabled
+      onStartShouldSetResponderCapture={() => true}
+      onMoveShouldSetResponderCapture={() => true}
+      onMomentumScrollBegin={handleMomentumBegin}
+      onMomentumScrollEnd={handleMomentumEnd}
+      onScrollBeginDrag={handleScrollBeginDrag}
+      onScrollEndDrag={handleScrollEndDrag}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {values.map((item, index) => {
+        const isActive = index === valueIndex;
+        return (
+          <View key={`${item}-${index}`} style={[styles.timerWheelItem, { height: itemHeight }]}>
+            <Text style={[styles.timerWheelItemText, isActive && styles.timerWheelItemTextActive]}>
+              {item}
+            </Text>
+          </View>
+        );
+      })}
+    </ScrollView>
   );
 }
 
@@ -4619,25 +4741,71 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   quantumModalAmountInput: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 10,
+    paddingVertical: 6,
     borderRadius: 18,
     borderWidth: 1,
     borderColor: '#D5DBE8',
     backgroundColor: '#F8FAFF',
+    overflow: 'hidden',
   },
-  quantumModalAmountValue: {
-    minWidth: 64,
-    textAlign: 'center',
-    fontSize: 28,
+  timerWheelArea: {
+    position: 'relative',
+    height: WHEEL_ITEM_HEIGHT * WHEEL_VISIBLE_ITEMS,
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    overflow: 'hidden',
+  },
+  timerWheelHighlight: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: WHEEL_ITEM_HEIGHT - 4,
+    height: WHEEL_ITEM_HEIGHT + 8,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(31,39,66,0.16)',
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#1F2742',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  timerWheelRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    gap: 12,
+  },
+  timerWheelDivider: {
+    alignSelf: 'center',
+    fontSize: 18,
     fontWeight: '700',
     color: '#1F2742',
   },
-  quantumModalAmountSeparator: {
-    fontSize: 26,
+  timerWheelColumn: {
+    width: '100%',
+  },
+  timerWheelColumnWrapper: {
+    width: 68,
+    height: WHEEL_ITEM_HEIGHT * WHEEL_VISIBLE_ITEMS,
+    overflow: 'hidden',
+  },
+  timerWheelColumnContent: {
+    paddingVertical: WHEEL_ITEM_HEIGHT,
+  },
+  timerWheelItem: {
+    height: WHEEL_ITEM_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timerWheelItemText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#A3AEC1',
+  },
+  timerWheelItemTextActive: {
+    fontSize: 22,
     fontWeight: '700',
     color: '#1F2742',
   },
@@ -5121,28 +5289,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     paddingHorizontal: 32,
     paddingTop: 24,
-  },
-  avatarContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: '#F0EFFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
-  profileTitle: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: '#1a1a2e',
-    marginBottom: 8,
-  },
-  profileSubtitle: {
-    fontSize: 15,
-    color: '#6f7a86',
-    textAlign: 'center',
-    marginBottom: 32,
-    lineHeight: 22,
   },
   profileStatsSection: {
     alignSelf: 'stretch',


### PR DESCRIPTION
### Motivation
- Make the white timer highlight bar wider and taller so its sides touch the grey modal background and touch targets are easier to use.
- Replace small numeric `TextInput` controls with a scrollable wheel UI to improve hour/minute selection ergonomics.
- Prevent wheel items from visually overflowing the modal by clipping wheel columns.
- Improve finalization of wheel scrolling and selection feedback.

### Description
- Expanded the `timerWheelHighlight` by changing `left`, `right`, `top`, `height`, and `borderRadius` so the white bar spans the full column width and is taller.
- Added a `WheelPicker` component and helpers: `WHEEL_ITEM_HEIGHT`, `WHEEL_VISIBLE_ITEMS`, `TIMER_HOUR_OPTIONS`, `TIMER_MINUTE_OPTIONS`, and `normalizeTimerValue`, and wired two `WheelPicker` instances for hours and minutes in the modal.
- Replaced the previous `TextInput` hour/minute fields with a `timerWheelArea` containing `timerWheelColumnWrapper` (with `overflow: 'hidden'`) and supporting styles (`timerWheelRow`, `timerWheelDivider`, `timerWheelColumn`, `timerWheelColumnContent`, `timerWheelItem`, `timerWheelItemText`, `timerWheelItemTextActive`).
- Adjusted `quantumModalAmountInput` padding and `overflow` to avoid visual bleed and fixed a missing dependency in `totalLabel` (`dateKey`) for correctness.

### Testing
- No automated tests were run for this change.
- No CI or build validation was executed as part of this edit.
- Manual UI tweak was applied and committed; visual verification is recommended on device/emulator to confirm sizing and interaction improvements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ab44e44832685e0f41447429a75)