### PR TITLE
Allow additive 30m/1h timer presets and add wheel picker for timer input

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,6 +7,7 @@ import {
   Easing,
   Platform,
   Image,
+  FlatList,
   Modal,
   PanResponder,
   Pressable,
@@ -15,7 +16,6 @@ import {
   StyleSheet,
   Text,
   TextInput,
-  FlatList,
   TouchableOpacity,
   View,
   useWindowDimensions,
@@ -2816,7 +2816,7 @@ function SwipeableTaskCard({
       return null;
     }
     return `${completedSubtasks}/${totalSubtasks}`;
-  }, [completedSubtasks, task, totalSubtasks]);
+  }, [completedSubtasks, dateKey, task, totalSubtasks]);
 
   const isQuantum = task.type === 'quantum';
   const isWaterAnimation = task.quantum?.animation === 'water';
@@ -3799,11 +3799,14 @@ function QuantumAdjustModal({
   const limitCount = task?.quantum?.count?.value ?? 0;
   const maxTimerMinutes = task?.quantum?.timer?.minutes ?? 0;
   const maxTimerSeconds = task?.quantum?.timer?.seconds ?? 0;
-  const maxTimerTotalSeconds = maxTimerMinutes * 60 + maxTimerSeconds;
+  const maxTimerTotalMinutes = maxTimerMinutes * 60 + maxTimerSeconds;
   const lastAdjustCount = task?.quantum?.lastAdjustCount ?? null;
   const normalizedCountValue = Number.parseInt(countValue, 10) || 0;
   const normalizedMinutesValue = Number.parseInt(minutesValue, 10) || 0;
   const normalizedSecondsValue = Number.parseInt(secondsValue, 10) || 0;
+  const totalTimerMinutes = normalizedMinutesValue * 60 + normalizedSecondsValue;
+  const isThirtySelected = totalTimerMinutes === 30 || totalTimerMinutes === 90;
+  const isOneHourSelected = totalTimerMinutes === 60 || totalTimerMinutes === 90;
   const lastCountValue = lastAdjustCount ?? Math.max(1, normalizedCountValue || 1);
   const halfCountValue = limitCount ? Math.max(1, Math.round(limitCount / 2)) : 0;
   const maxCountValue = limitCount ?? 0;
@@ -3844,6 +3847,32 @@ function QuantumAdjustModal({
     },
     [onChangeMinutes, onChangeSeconds]
   );
+  const updateTimerFromTotal = useCallback(
+    (totalMinutes) => {
+      const clampedTotal =
+        maxTimerTotalMinutes > 0
+          ? Math.min(Math.max(totalMinutes, 0), maxTimerTotalMinutes)
+          : Math.max(totalMinutes, 0);
+      const nextHours = Math.floor(clampedTotal / 60);
+      const nextMinutes = clampedTotal % 60;
+      onChangeMinutes(String(nextHours));
+      onChangeSeconds(String(nextMinutes));
+    },
+    [maxTimerTotalMinutes, onChangeMinutes, onChangeSeconds]
+  );
+  const handleTimerPresetToggle = useCallback(
+    (presetMinutes) => {
+      if (!presetMinutes) {
+        return;
+      }
+      const shouldRemove =
+        (presetMinutes === 30 && isThirtySelected) ||
+        (presetMinutes === 60 && isOneHourSelected);
+      const nextTotal = shouldRemove ? totalTimerMinutes - presetMinutes : totalTimerMinutes + presetMinutes;
+      updateTimerFromTotal(nextTotal);
+    },
+    [isOneHourSelected, isThirtySelected, totalTimerMinutes, updateTimerFromTotal]
+  );
   const disableActions = isTimer
     ? (Number.parseInt(minutesValue, 10) || 0) * 60 + (Number.parseInt(secondsValue, 10) || 0) <= 0
     : (Number.parseInt(countValue, 10) || 0) <= 0;
@@ -3879,20 +3908,16 @@ function QuantumAdjustModal({
                 <Pressable
                   style={[
                     styles.quantumModalPresetButton,
-                    normalizedMinutesValue === 0 &&
-                      normalizedSecondsValue === 30 &&
-                      styles.quantumModalPresetButtonSelected,
+                    isThirtySelected && styles.quantumModalPresetButtonSelected,
                   ]}
-                  onPress={() => handleTimerPresetSelect(0, 30)}
+                  onPress={() => handleTimerPresetToggle(30)}
                   accessibilityRole="button"
                   accessibilityLabel="Use 30 minutes"
                 >
                   <Text
                     style={[
                       styles.quantumModalPresetText,
-                      normalizedMinutesValue === 0 &&
-                        normalizedSecondsValue === 30 &&
-                        styles.quantumModalPresetTextSelected,
+                      isThirtySelected && styles.quantumModalPresetTextSelected,
                     ]}
                   >
                     30 min
@@ -3901,20 +3926,16 @@ function QuantumAdjustModal({
                 <Pressable
                   style={[
                     styles.quantumModalPresetButton,
-                    normalizedMinutesValue === 1 &&
-                      normalizedSecondsValue === 0 &&
-                      styles.quantumModalPresetButtonSelected,
+                    isOneHourSelected && styles.quantumModalPresetButtonSelected,
                   ]}
-                  onPress={() => handleTimerPresetSelect(1, 0)}
+                  onPress={() => handleTimerPresetToggle(60)}
                   accessibilityRole="button"
                   accessibilityLabel="Use 1 hour"
                 >
                   <Text
                     style={[
                       styles.quantumModalPresetText,
-                      normalizedMinutesValue === 1 &&
-                        normalizedSecondsValue === 0 &&
-                        styles.quantumModalPresetTextSelected,
+                      isOneHourSelected && styles.quantumModalPresetTextSelected,
                     ]}
                   >
                     1 hour
@@ -3925,20 +3946,20 @@ function QuantumAdjustModal({
                     styles.quantumModalPresetButton,
                     normalizedMinutesValue === maxTimerMinutes &&
                       normalizedSecondsValue === maxTimerSeconds &&
-                      maxTimerTotalSeconds > 0 &&
+                      maxTimerTotalMinutes > 0 &&
                       styles.quantumModalPresetButtonSelected,
                   ]}
                   onPress={() => handleTimerPresetSelect(maxTimerMinutes, maxTimerSeconds)}
                   accessibilityRole="button"
                   accessibilityLabel="Use max"
-                  disabled={maxTimerTotalSeconds <= 0}
+                  disabled={maxTimerTotalMinutes <= 0}
                 >
                   <Text
                     style={[
                       styles.quantumModalPresetText,
                       normalizedMinutesValue === maxTimerMinutes &&
                         normalizedSecondsValue === maxTimerSeconds &&
-                        maxTimerTotalSeconds > 0 &&
+                        maxTimerTotalMinutes > 0 &&
                         styles.quantumModalPresetTextSelected,
                     ]}
                   >
@@ -3949,27 +3970,28 @@ function QuantumAdjustModal({
               <View style={styles.quantumModalAmount}>
                 <Text style={styles.quantumModalAmountLabel}>Amount</Text>
                 <View style={styles.quantumModalAmountInput}>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={minutesValue}
-                    onChangeText={handleMinutesChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer hours"
-                  />
-                  <Text style={styles.quantumModalAmountSeparator}>:</Text>
-                  <TextInput
-                    style={styles.quantumModalAmountValue}
-                    value={secondsValue}
-                    onChangeText={handleSecondsChange}
-                    keyboardType="number-pad"
-                    maxLength={2}
-                    placeholder="00"
-                    placeholderTextColor="#B4BCCB"
-                    accessibilityLabel="Timer minutes"
-                  />
+                  <View style={styles.timerWheelArea}>
+                    <View pointerEvents="none" style={styles.timerWheelHighlight} />
+                    <View style={styles.timerWheelRow}>
+                      <View style={styles.timerWheelColumnWrapper}>
+                        <WheelPicker
+                          values={TIMER_HOUR_OPTIONS}
+                          value={normalizeTimerValue(minutesValue, TIMER_HOUR_OPTIONS)}
+                          onChange={handleMinutesChange}
+                          accessibilityLabel="Timer hours"
+                        />
+                      </View>
+                      <Text style={styles.timerWheelDivider}>:</Text>
+                      <View style={styles.timerWheelColumnWrapper}>
+                        <WheelPicker
+                          values={TIMER_MINUTE_OPTIONS}
+                          value={normalizeTimerValue(secondsValue, TIMER_MINUTE_OPTIONS)}
+                          onChange={handleSecondsChange}
+                          accessibilityLabel="Timer minutes"
+                        />
+                      </View>
+                    </View>
+                  </View>
                 </View>
               </View>
             </>
@@ -4074,6 +4096,127 @@ function QuantumAdjustModal({
         </View>
       </View>
     </Modal>
+  );
+}
+
+const WHEEL_ITEM_HEIGHT = 34;
+const WHEEL_VISIBLE_ITEMS = 3;
+
+const TIMER_HOUR_OPTIONS = Array.from({ length: 100 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+const TIMER_MINUTE_OPTIONS = Array.from({ length: 60 }, (_, index) =>
+  String(index).padStart(2, '0')
+);
+
+function normalizeTimerValue(value, options) {
+  const sanitized = value?.replace(/\D/g, '') ?? '';
+  if (!sanitized) {
+    return options[0];
+  }
+  const normalized = Number.parseInt(sanitized, 10);
+  if (Number.isNaN(normalized)) {
+    return options[0];
+  }
+  const clamped = Math.min(Math.max(normalized, 0), options.length - 1);
+  return options[clamped];
+}
+
+function WheelPicker({ values, value, onChange, accessibilityLabel, itemHeight = WHEEL_ITEM_HEIGHT }) {
+  const scrollRef = useRef(null);
+  const isMomentumScrolling = useRef(false);
+  const isDragging = useRef(false);
+  const valueIndex = Math.max(0, values.indexOf(value));
+
+  useEffect(() => {
+    if (!scrollRef.current || isMomentumScrolling.current || isDragging.current) {
+      return undefined;
+    }
+    const frame = requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ y: valueIndex * itemHeight, animated: false });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [valueIndex, itemHeight]);
+
+  const finalizeSelection = useCallback(
+    (offsetY) => {
+      const maxOffset = Math.max(0, (values.length - 1) * itemHeight);
+      const clampedOffset = Math.min(Math.max(offsetY, 0), maxOffset);
+      const index = Math.round(clampedOffset / itemHeight);
+      const clampedIndex = Math.min(Math.max(index, 0), values.length - 1);
+      const nextValue = values[clampedIndex];
+
+      if (nextValue && clampedIndex !== valueIndex) {
+        onChange(nextValue);
+        if (HAPTICS_SUPPORTED && typeof Haptics.selectionAsync === 'function') {
+          try {
+            Haptics.selectionAsync();
+          } catch {
+            // Ignore missing haptics support on web
+          }
+        }
+      }
+    },
+    [itemHeight, onChange, valueIndex, values]
+  );
+
+  const handleMomentumBegin = useCallback(() => {
+    isMomentumScrolling.current = true;
+  }, []);
+
+  const handleMomentumEnd = useCallback(
+    (event) => {
+      isMomentumScrolling.current = false;
+      finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+    },
+    [finalizeSelection]
+  );
+
+  const handleScrollBeginDrag = useCallback(() => {
+    isDragging.current = true;
+  }, []);
+
+  const handleScrollEndDrag = useCallback(
+    (event) => {
+      isDragging.current = false;
+      if (!isMomentumScrolling.current) {
+        finalizeSelection(event.nativeEvent.contentOffset.y ?? 0);
+      }
+    },
+    [finalizeSelection]
+  );
+
+  return (
+    <ScrollView
+      ref={scrollRef}
+      style={styles.timerWheelColumn}
+      contentContainerStyle={[styles.timerWheelColumnContent, { paddingVertical: itemHeight }]}
+      showsVerticalScrollIndicator={false}
+      snapToInterval={itemHeight}
+      decelerationRate={Platform.select({ ios: 'fast', android: 0.998 })}
+      overScrollMode="never"
+      bounces
+      scrollEventThrottle={16}
+      nestedScrollEnabled
+      onStartShouldSetResponderCapture={() => true}
+      onMoveShouldSetResponderCapture={() => true}
+      onMomentumScrollBegin={handleMomentumBegin}
+      onMomentumScrollEnd={handleMomentumEnd}
+      onScrollBeginDrag={handleScrollBeginDrag}
+      onScrollEndDrag={handleScrollEndDrag}
+      accessibilityLabel={accessibilityLabel}
+    >
+      {values.map((item, index) => {
+        const isActive = index === valueIndex;
+        return (
+          <View key={`${item}-${index}`} style={[styles.timerWheelItem, { height: itemHeight }]}>
+            <Text style={[styles.timerWheelItemText, isActive && styles.timerWheelItemTextActive]}>
+              {item}
+            </Text>
+          </View>
+        );
+      })}
+    </ScrollView>
   );
 }
 
@@ -4619,25 +4762,71 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   quantumModalAmountInput: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    paddingVertical: 10,
+    paddingVertical: 6,
     borderRadius: 18,
     borderWidth: 1,
     borderColor: '#D5DBE8',
     backgroundColor: '#F8FAFF',
+    overflow: 'hidden',
   },
-  quantumModalAmountValue: {
-    minWidth: 64,
-    textAlign: 'center',
-    fontSize: 28,
+  timerWheelArea: {
+    position: 'relative',
+    height: WHEEL_ITEM_HEIGHT * WHEEL_VISIBLE_ITEMS,
+    justifyContent: 'center',
+    paddingHorizontal: 6,
+    overflow: 'hidden',
+  },
+  timerWheelHighlight: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: WHEEL_ITEM_HEIGHT - 4,
+    height: WHEEL_ITEM_HEIGHT + 8,
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: 'rgba(31,39,66,0.16)',
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#1F2742',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  timerWheelRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    gap: 6,
+  },
+  timerWheelDivider: {
+    alignSelf: 'center',
+    fontSize: 18,
     fontWeight: '700',
     color: '#1F2742',
   },
-  quantumModalAmountSeparator: {
-    fontSize: 26,
+  timerWheelColumn: {
+    width: '100%',
+  },
+  timerWheelColumnWrapper: {
+    width: 90,
+    height: WHEEL_ITEM_HEIGHT * WHEEL_VISIBLE_ITEMS,
+    overflow: 'hidden',
+  },
+  timerWheelColumnContent: {
+    paddingVertical: WHEEL_ITEM_HEIGHT,
+  },
+  timerWheelItem: {
+    height: WHEEL_ITEM_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  timerWheelItemText: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#A3AEC1',
+  },
+  timerWheelItemTextActive: {
+    fontSize: 22,
     fontWeight: '700',
     color: '#1F2742',
   },
@@ -5121,28 +5310,6 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-start',
     paddingHorizontal: 32,
     paddingTop: 24,
-  },
-  avatarContainer: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: '#F0EFFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
-  profileTitle: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: '#1a1a2e',
-    marginBottom: 8,
-  },
-  profileSubtitle: {
-    fontSize: 15,
-    color: '#6f7a86',
-    textAlign: 'center',
-    marginBottom: 32,
-    lineHeight: 22,
   },
   profileStatsSection: {
     alignSelf: 'stretch',

--- a/utils/timeUtils.js
+++ b/utils/timeUtils.js
@@ -27,9 +27,9 @@ const formatTaskTime = (time) => {
 
 const formatDuration = (totalSeconds) => {
   const safeSeconds = Math.max(0, totalSeconds || 0);
-  const minutes = Math.floor(safeSeconds / 60);
-  const seconds = safeSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  return `${hours}:${formatNumber(minutes)}`;
 };
 
 export { formatDuration, formatNumber, formatTaskTime, formatTimeValue, toMinutes };


### PR DESCRIPTION
### Motivation
- Let users select the 30 minute and 1 hour presets additively so both can be combined to get `01:30` in the timer adjust modal.
- Improve timer editing UX by replacing the raw numeric `TextInput` fields with a scrollable wheel-style picker for hours and minutes.
- Ensure preset toggles respect and clamp to the configured maximum timer value when adjusting presets.
- Keep duration formatting consistent by using hours and zero-padded minutes for display.

### Description
- Implemented additive preset behavior in `App.js` by introducing `totalTimerMinutes`, `isThirtySelected`, `isOneHourSelected`, `handleTimerPresetToggle`, and `updateTimerFromTotal` to toggle/add presets and clamp changes to `maxTimerTotalMinutes`.
- Replaced the numeric timer `TextInput` controls with a custom `WheelPicker` component and helper `normalizeTimerValue`, and added `TIMER_HOUR_OPTIONS` and `TIMER_MINUTE_OPTIONS` for the wheel data.
- Added wheel-related styles and layout (highlight, column, item styling), adjusted presets to use `maxTimerTotalMinutes` checks, and kept the existing `max` preset behavior.
- Updated `utils/timeUtils.js` so `formatDuration` returns `hours:MM` using `formatNumber` for zero-padding.

### Testing
- No automated tests were run for these changes.
- No CI/test execution was performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69625ab44e44832685e0f41447429a75)