### PR TITLE
Request notification permission when scheduling reminders

### DIFF
--- a/App.js
+++ b/App.js
@@ -255,6 +255,22 @@ const ensureNotificationChannel = async () => {
   });
 };
 
+const ensureNotificationPermissions = async () => {
+  try {
+    const settings = await Notifications.getPermissionsAsync();
+    if (settings.granted) {
+      return true;
+    }
+    if (settings.canAskAgain === false) {
+      return false;
+    }
+    const result = await Notifications.requestPermissionsAsync();
+    return result.granted;
+  } catch (error) {
+    return false;
+  }
+};
+
 const scheduleTaskNotification = async (task) => {
   if (!task?.reminder || task.reminder === 'none') {
     return [];
@@ -263,8 +279,8 @@ const scheduleTaskNotification = async (task) => {
   if (!referenceTime) {
     return [];
   }
-  const permissions = await Notifications.getPermissionsAsync();
-  if (!permissions.granted) {
+  const granted = await ensureNotificationPermissions();
+  if (!granted) {
     return [];
   }
   await ensureNotificationChannel();


### PR DESCRIPTION
### Motivation
- Users reported that running in Expo Go did not prompt for notification permission when saving a habit, so scheduling reminders should request permission before scheduling.
- The change aims to ensure the app prompts for notification access at the time of scheduling rather than silently failing to schedule reminders.

### Description
- Add a helper `ensureNotificationPermissions` that checks current permissions and requests them if allowed via `Notifications.getPermissionsAsync` and `Notifications.requestPermissionsAsync`.
- Use `ensureNotificationPermissions` inside `scheduleTaskNotification` and return early if permission is not granted.
- Preserve existing Android channel setup with `ensureNotificationChannel` before scheduling.

### Testing
- No automated tests were run for this change.
- Manual behavior to verify is that the notification permission prompt appears when scheduling a reminder if permission is not already granted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a736e5fc83269bf0afe8d2321197)