### PR TITLE
Add passive Reminder card type and exclude it from completion metrics

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -121,6 +121,7 @@ const DEFAULT_TYPE_OPTIONS = [
   { key: 'default', label: 'Defaut' },
   { key: 'quantum', label: 'Quantum' },
   { key: 'list', label: 'List' },
+  { key: 'reminder', label: 'Reminder' },
 ];
 
 const QUANTUM_MODES = [


### PR DESCRIPTION
### Motivation
- Provide a new `Reminder` task/card type that behaves as a passive reminder (visible on scheduled dates/times) and does not affect daily success/completion metrics or streaks.

### Description
- Add `Reminder` to the type selector `DEFAULT_TYPE_OPTIONS` in `components/AddHabitSheet.js` so it can be chosen when creating/editing tasks. (`components/AddHabitSheet.js`).
- Introduce helpers `isPassiveTaskType` and `shouldCountTaskTowardsCompletion` and use them to exclude `reminder` tasks from scoring logic used across the app (day report, calendar day status, today counter, and profile streaks). (`App.js`).
- Hide/disable completion UI and behavior for reminders by removing the completion toggle in list cards and task detail modal, and by preventing programmatic toggles in `handleToggleTaskCompletion` when the target is a passive task. (`App.js`).
- Update day report rendering to compute success rate and show completion indicators only for scorable tasks (i.e. non-`reminder`). (`App.js`).

### Testing
- Ran static checks: `node --check App.js` succeeded. 
- Ran static checks: `node --check components/AddHabitSheet.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a314f9ca4832680361790acad7122)