### PR TITLE
Optimize calendar/task rendering and persistence hot paths

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -6,7 +6,6 @@ import {
   Easing,
   Image,
   KeyboardAvoidingView,
-  PanResponder,
   Platform,
   Pressable,
   ScrollView,
@@ -557,7 +556,6 @@ export default function AddHabitSheet({
   const isEditMode = mode === 'edit';
   const isCopyMode = mode === 'copy';
   const submitLabel = isEditMode ? common.save : common.create;
-  const isDragCloseEnabled = false;
   const accessibilityAnnouncement = isEditMode
     ? 'Edit habit'
     : isCopyMode
@@ -1260,60 +1258,6 @@ export default function AddHabitSheet({
     typeOptions,
   ]);
 
-  const panResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onMoveShouldSetPanResponder: (_, gestureState) =>
-          isDragCloseEnabled &&
-          visible &&
-          !activePanel &&
-          gestureState.dy > 14 &&
-          Math.abs(gestureState.dx) < 8,
-        onPanResponderMove: (_, gestureState) => {
-          if (!isDragCloseEnabled || !visible) {
-            return;
-          }
-          const offset = Math.max(0, gestureState.dy);
-          translateY.setValue(offset);
-        },
-        onPanResponderRelease: (_, gestureState) => {
-          if (!isDragCloseEnabled || !visible) {
-            return;
-          }
-          const shouldClose = gestureState.vy > 1.2 || gestureState.dy > sheetHeight * 0.25;
-          if (shouldClose) {
-            handleClose();
-          } else {
-            Animated.spring(translateY, {
-              toValue: 0,
-              damping: 18,
-              stiffness: 220,
-              mass: 0.9,
-              useNativeDriver: USE_NATIVE_DRIVER,
-            }).start();
-          }
-        },
-        onPanResponderTerminate: (_, gestureState) => {
-          if (!isDragCloseEnabled || !visible) {
-            return;
-          }
-          const shouldClose = gestureState.vy > 1.2 || gestureState.dy > sheetHeight * 0.25;
-          if (shouldClose) {
-            handleClose();
-          } else {
-            Animated.spring(translateY, {
-              toValue: 0,
-              damping: 18,
-              stiffness: 220,
-              mass: 0.9,
-              useNativeDriver: USE_NATIVE_DRIVER,
-            }).start();
-          }
-        },
-      }),
-    [activePanel, handleClose, isDragCloseEnabled, sheetHeight, translateY, visible]
-  );
-
   const isSubmitDisabled = !title.trim();
 
   const formatDateLabelLocalized = useCallback((date) => {
@@ -1644,7 +1588,6 @@ export default function AddHabitSheet({
         ]}
         accessibilityViewIsModal
         importantForAccessibility="yes"
-        {...(!activePanel && isDragCloseEnabled ? panResponder.panHandlers : {})}
       >
         <KeyboardAvoidingView
           style={styles.keyboardAvoiding}


### PR DESCRIPTION
### Motivation
- Reduce unnecessary re-renders in calendar and task lists to improve UI responsiveness and battery usage.  
- Avoid redundant AsyncStorage writes that can cause UI stutters by separating persistence concerns.  
- Lower initial load cost for the calendar and remove dead gesture code that increases bundle size and cognitive overhead.  

### Description
- Wrapped `CalendarDayCell`, `CalendarMonthItem`, and `SwipeableTaskCard` with `React.memo` to minimize list re-renders.  
- Replaced repeated `new Date()` checks per calendar cell with a parent-computed `todayKey` and comparison via `getDateKey(day)`.  
- Split the debounced persistence `useEffect` into three focused effects for `tasks` (`saveTasks`), `userSettings` (`saveUserSettings`), and `history` (`saveHistory`) so only the relevant state triggers each write.  
- Reduced initial `calendarMonths` range from `-60..+24` to `-12..+12` and adjusted the `initialScrollIndex` fallback, and removed the disabled `PanResponder`/`isDragCloseEnabled` usage and import from `AddHabitSheet.js` to eliminate dead gesture code.  

### Testing
- Syntax checks passed for modified files: `node --check App.js` (success).  
- Syntax checks passed for modified files: `node --check components/AddHabitSheet.js` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba083fa5c83268c1b132b803f68ca)