### PR TITLE
Fix DatePanel crash when selecting repeat end date

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -2565,7 +2565,7 @@ function SubtasksPanel({ value, onChange, infoText, onPressInfo, isInfoVisible =
   );
 }
 
-function DatePanel({ month, selectedDate, onSelectDate, onChangeMonth, repeatConfig, labels }) {
+function DatePanel({ month, selectedDate, onSelectDate, onChangeMonth, repeatConfig, labels = {} }) {
   const today = useMemo(() => normalizeDate(new Date()), []);
   const [visibleMonth, setVisibleMonth] = useState(() => normalizeDate(month));
 
@@ -2959,6 +2959,7 @@ function RepeatPanel({
                   onSelectDate={onChangeEndDate}
                   onChangeMonth={setEndDateMonth}
                   repeatConfig={{ enabled: false }}
+                  labels={labels}
                 />
               </View>
             )}


### PR DESCRIPTION
### Motivation
- Selecting a repeat end date rendered `DatePanel` without `labels`, causing `TypeError: Cannot read properties of undefined (reading 'quickToday')` when the panel accessed `labels.quickToday`.

### Description
- Made `DatePanel` tolerant to a missing `labels` prop by adding a default `labels = {}` and passed `labels` into the end-date `DatePanel` instance inside `RepeatPanel` to ensure localized strings are available (`components/AddHabitSheet.js`).

### Testing
- Ran a dependency listing check with `npm -s ls --depth=0`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cd8df73a8832692b218279a8e7705)