### PR TITLE
Fix subtasks info tooltip stacking order

### DIFF
--- a/components/AddHabitSheet.js
+++ b/components/AddHabitSheet.js
@@ -3473,6 +3473,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     alignSelf: 'flex-start',
     position: 'relative',
+    zIndex: 20,
+    elevation: 20,
   },
   subtasksCard: {
     backgroundColor: '#FFFFFF',
@@ -3486,6 +3488,7 @@ const styles = StyleSheet.create({
     shadowRadius: 12,
     elevation: 6,
     overflow: 'hidden',
+    zIndex: 1,
   },
   quantumModeRow: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
- The help tooltip for the subtasks info button was being hidden behind the add-subtask input card, making the bubble unreadable when the icon is tapped.

### Description
- Raise the stacking priority of the tooltip anchor row by adding `zIndex: 20` and `elevation: 20` to `sectionTitleRow` in `components/AddHabitSheet.js`.
- Lower the card stacking by adding `zIndex: 1` to `subtasksCard` in `components/AddHabitSheet.js` so the floating info bubble can render above it.

### Testing
- There is no automated test suite for UI/layout in this repository, so no unit tests were run.
- Attempted an automated visual check by capturing a browser screenshot via Playwright, but the local dev server at `http://localhost:19006` did not respond and the screenshot run failed with `ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce28c5dc883269c9bb7c2994f13fb)