### PR TITLE
Fix lock icon alignment with wrapped task titles

### DIFF
--- a/App.js
+++ b/App.js
@@ -4237,15 +4237,15 @@ function TaskDetailModal({
                 <Text style={styles.detailEmoji}>{task.emoji || FALLBACK_EMOJI}</Text>
               )}
               <View style={styles.detailTitleContainer}>
-                <View style={styles.detailTitleRow}>
-                  <Text style={styles.detailTitle}>{task.title}</Text>
+                <Text style={styles.detailTitle}>
+                  {task.title}{' '}
                   <Ionicons
                     name={task.profileLocked ? 'lock-closed' : 'lock-open-outline'}
                     size={14}
                     color="#9aa5b5"
                     style={styles.detailTitleLock}
                   />
-                </View>
+                </Text>
                 <Text style={styles.detailTime}>{formatTaskTime(task.time, { language, anytimeLabel: t.sheet.anytime })}</Text>
                 {quantumLabel ? (
                   <Text style={styles.detailSubtaskSummaryLabel}>{quantumLabel}</Text>
@@ -5194,11 +5194,6 @@ const styles = StyleSheet.create({
     marginLeft: 12,
     flex: 1,
   },
-  detailTitleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
   detailTitle: {
     fontSize: 20,
     fontWeight: '700',
@@ -5206,6 +5201,7 @@ const styles = StyleSheet.create({
   },
   detailTitleLock: {
     opacity: 0.7,
+    lineHeight: 20,
   },
   detailTime: {
     marginTop: 4,


### PR DESCRIPTION
### Motivation
- Long task titles were wrapping to a second line while the lock icon was rendered in a separate row, causing the icon to appear at the card edge instead of next to the title.
- The goal is to keep the lock icon visually attached to the title and follow line breaks so it always appears adjacent to the task name.

### Description
- In `TaskDetailModal` (file `App.js`) replaced the separate title row (`detailTitleRow` containing a `<Text>` and an `<Ionicons>`) with a single inline `<Text>` that renders `{task.title}` and the `Ionicons` inside the same text node so the icon follows wraps.
- Removed the now-unused `detailTitleRow` style and added a `lineHeight: 20` tweak to `detailTitleLock` to better vertically align the icon with the title baseline.
- No other visual or functional behavior of the modal was changed; time, emoji/fallback, and subtask summary rendering remain the same.

### Testing
- Ran `npm run lint` which failed because the project has no `lint` script configured, so no lint checks were executed.
- Ran `npm test` which failed because the project has no `test` script configured, so no automated unit tests were executed.
- Attempted an automated screenshot via Playwright (`mcp__browser_tools__run_playwright_script`) to visually validate the fix, but the Chromium browser failed to launch in this environment (SIGSEGV), so no screenshot could be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf1d3e3408326b4f228bc5bf3a8aa)